### PR TITLE
Enhance QNez instruction and tests

### DIFF
--- a/python/src/hhat_lang/core/data/core.py
+++ b/python/src/hhat_lang/core/data/core.py
@@ -183,7 +183,10 @@ class CoreLiteral(WorkingData):
         self._type = lit_type
         self._is_quantum = True if lit_type.startswith("@") else False
         self._suppress_type = False
-        self._bin_form = bin(int(value.strip("@")))[2:]
+        if lit_type == "@bool" and value in ("@true", "@false"):
+            self._bin_form = "1" if value == "@true" else "0"
+        else:
+            self._bin_form = bin(int(value.strip("@")))[2:]
 
     @property
     def value(self) -> str:

--- a/python/tests/lowlevel/qlang/openqasm/v2/test_lowlevelqlang.py
+++ b/python/tests/lowlevel/qlang/openqasm/v2/test_lowlevelqlang.py
@@ -218,12 +218,12 @@ measure q -> c;
     block.add_instr(
         IRInstr(
             Symbol("@nez"),
-            IRArgs(CoreLiteral("@5", "@u3"), Symbol("@not")),
+            IRArgs(CoreLiteral("@5", "@u3"), Symbol("@v"), Symbol("@not")),
             InstrIRFlag.CALL,
         )
     )
 
-    qlang = LowLeveQLang(qv, block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
     res = qlang.gen_program()
 
     assert res == code_snippet
@@ -243,12 +243,12 @@ def test_gen_program_nez_zero_mask() -> None:
     block.add_instr(
         IRInstr(
             Symbol("@nez"),
-            IRArgs(CoreLiteral("@0", "@u3"), Symbol("@not")),
+            IRArgs(CoreLiteral("@0", "@u3"), Symbol("@v"), Symbol("@not")),
             InstrIRFlag.CALL,
         )
     )
 
-    qlang = LowLeveQLang(qv, block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
     res = qlang.gen_program()
 
     assert res == code_snippet
@@ -275,12 +275,12 @@ measure q -> c;
     block.add_instr(
         IRInstr(
             Symbol("@nez"),
-            IRArgs(Symbol("@true"), Symbol("@redim")),
+            IRArgs(Symbol("@true"), Symbol("@v"), Symbol("@redim")),
             InstrIRFlag.CALL,
         )
     )
 
-    qlang = LowLeveQLang(qv, block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
     res = qlang.gen_program()
 
     assert res == code_snippet
@@ -307,12 +307,12 @@ measure q -> c;
     block.add_instr(
         IRInstr(
             Symbol("@nez"),
-            IRArgs(Symbol("@true"), Symbol("@not")),
+            IRArgs(Symbol("@true"), Symbol("@v"), Symbol("@not")),
             InstrIRFlag.CALL,
         )
     )
 
-    qlang = LowLeveQLang(qv, block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
     res = qlang.gen_program()
 
     assert res == code_snippet


### PR DESCRIPTION
Further improvement from #58

1. To address using `@true`/`@false` rather than numeric values, modification was required and `CoreLiteral` now interprets these boolean literals directly. Without mapping `@true` and `@false` to `"1"` and `"0"`, the bin property would be missing for these literals and `QNez._get_mask_idxs` would fail when it reads `literal.bin`. When the type is `@bool`, the constructor maps the strings to `”1”` or `”0”` for the binary form.
So eventually, `Qnez` use `CoreLiteral("@true", "@bool”)` and `CoreLiteral("@false", "@bool”)`

2. The `@nez` instruction now requires an explicit target in its IR arguments.  
`IRInstr(Symbol("@nez"), IRArgs(CoreLiteral("@5", "@u3"), Symbol("@v"), Symbol("@not")), InstrIRFlag.CALL)` which corresponds to Heather code `@nez(@5) { @not(@v) }`
