### PR TITLE
Add new ideas for `IR`

### DIFF
--- a/python/src/hhat_lang/core/code/ir.py
+++ b/python/src/hhat_lang/core/code/ir.py
@@ -90,7 +90,6 @@ class BodyIR:
 
     def push(self, new_item: Any, to_instr_fn: Callable | None = None) -> None:
         if not isinstance(new_item, InstrIR | BlockIR):
-
             if to_instr_fn is not None:
                 new_item = to_instr_fn(new_item)
 

--- a/python/src/hhat_lang/core/code/utils.py
+++ b/python/src/hhat_lang/core/code/utils.py
@@ -22,7 +22,6 @@ def check_quantum_type_correctness(names: tuple[str, ...]) -> None:
     prev_quantum = False
     cur_quantum = False
     for n, name in enumerate(names):
-
         if n != 0 and cur_quantum and not prev_quantum:
             raise ValueError(
                 f"{name} is an attribute from a non-quantum symbol. "

--- a/python/src/hhat_lang/core/data/core.py
+++ b/python/src/hhat_lang/core/data/core.py
@@ -18,7 +18,7 @@ ACCEPTABLE_VALUES: dict = {
 
 
 class InvalidType:
-    """It just exists to be used as 'default' instance for the `ACCEPTABLE_VALUES` above."""
+    """It just exists to be used as 'default' instance for the ``ACCEPTABLE_VALUES`` above."""
 
     pass
 
@@ -184,10 +184,6 @@ class CoreLiteral(WorkingData):
         self._is_quantum = True if lit_type.startswith("@") else False
         self._suppress_type = False
         self._bin_form = bin(int(value.strip("@")))[2:]
-
-    @property
-    def value(self) -> str:
-        return self._value
 
     @property
     def bin(self) -> str:

--- a/python/src/hhat_lang/core/data/fn_def.py
+++ b/python/src/hhat_lang/core/data/fn_def.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Iterable
+
+from hhat_lang.core.data.core import Symbol, CompositeSymbol
+
+
+class BaseFnKey:
+    """
+    Base class for functions definition on memory's SymbolTable.
+    Provide functions a signature.
+
+    Given a function:
+
+    ```
+    fn sum (a:u64 b:u64) u64 { ::add(a b) }
+    ```
+
+    The function key object is as follows:
+
+    ```
+    BaseFnKey(
+        name=Symbol("sum"),
+        type=Symbol("u64"),
+        args_names=(Symbol("a"), Symbol("b"),),
+        args_types=(Symbol("u64"), Symbol("u64"),)
+    )
+    ```
+
+    When trying to retrieve the function data, use `BaseFnCheck`
+    parent instance instead:
+
+
+    """
+
+    _name: Symbol
+    _type: Symbol | CompositeSymbol
+    _args_types: tuple | tuple[Symbol | CompositeSymbol, ...]
+    _args_names: tuple | tuple[Symbol, ...]
+
+    # TODO: implement code for comparison of out of order args_names
+
+    def __init__(
+        self,
+        fn_name: Symbol,
+        fn_type: Symbol | CompositeSymbol,
+        args_names: tuple | tuple[Symbol, ...],
+        args_types: tuple | tuple[Symbol | CompositeSymbol, ...],
+    ):
+
+        # check correct types for each argument before proceeding
+        assert (
+            isinstance(fn_name, Symbol)
+            and isinstance(fn_type, Symbol | CompositeSymbol)
+            and all(isinstance(k, Symbol) for k in args_names)
+            and all(isinstance(p, Symbol | CompositeSymbol) for p in args_types),
+            f"Wrong types provided for function definition on SymbolTable:\n"
+            f"  name: {fn_name}\n  type: {fn_type}\n  args types: {args_types}\n"
+            f"  args names: {args_names}\n",
+        )
+
+        self._name = fn_name
+        self._type = fn_type
+        self._args_names = args_names
+        self._args_types = args_types
+
+    @property
+    def name(self) -> Symbol:
+        return self._name
+
+    @property
+    def type(self) -> Symbol | CompositeSymbol:
+        return self._type
+
+    @property
+    def args_types(self) -> tuple | tuple[Symbol | CompositeSymbol, ...]:
+        return self._args_types
+
+    @property
+    def args_names(self) -> tuple | tuple[Symbol, ...]:
+        return self._args_names
+
+    def __hash__(self) -> int:
+        return hash((self._name, self._type, self._args_types))
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, BaseFnKey | BaseFnCheck):
+            return (
+                self._name == other._name
+                and self._type == other._type
+                and self._args_types == other._args_types
+            )
+
+        return False
+
+    def has_args(self, args: tuple[Symbol, ...]) -> bool:
+        return set(self._args_names) == set(args)
+
+
+class BaseFnCheck:
+    """
+    Base function class to check and retrieve a given function from the SymbolTable.
+    """
+
+    _name: Symbol
+    _type: Symbol | CompositeSymbol
+    _args_types: tuple | tuple[Symbol | CompositeSymbol, ...]
+    _args_names: tuple | tuple[Symbol, ...]
+
+    def __init__(
+        self,
+        fn_name: Symbol,
+        fn_type: Symbol | CompositeSymbol,
+        args_types: tuple | tuple[Symbol | CompositeSymbol, ...],
+    ):
+
+        # checks types correctness
+        assert (
+            isinstance(fn_name, Symbol)
+            and isinstance(fn_type, Symbol | CompositeSymbol)
+            and all(isinstance(p, Symbol | CompositeSymbol) for p in args_types),
+            f"Wrong types provided for function retrieval on SymbolTable:\n"
+            f"  name: {fn_name}\n  type: {fn_type}\n  args types: {args_types}\n",
+        )
+
+        self._name = fn_name
+        self._type = fn_type
+        self._args_types = args_types
+
+    def __hash__(self) -> int:
+        return hash((self._name, self._type, self._args_types))
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, BaseFnKey | BaseFnCheck):
+            return (
+                self._name == other._name
+                and self._type == other._type
+                and self._args_types == other._args_types
+            )
+
+        return False

--- a/python/src/hhat_lang/core/data/variable.py
+++ b/python/src/hhat_lang/core/data/variable.py
@@ -128,12 +128,9 @@ class BaseDataContainer(ABC):
         """
 
         if data.type == attr_type:
-
             # is quantum or array data structure
             if data.is_quantum or self._check_array_prop(data):
-
                 if attr_type in self._ds:
-
                     if attr_type in self._data:
                         self._data[attr_type].append(data)
 
@@ -168,10 +165,8 @@ class BaseDataContainer(ABC):
         """
 
         if key in self._ds:
-
             # is quantum or array data structure
             if key.is_quantum or self._check_array_prop(value):
-
                 if key in self._data:
                     self._data[key].append(value)
 
@@ -235,15 +230,12 @@ class VariableTemplate:
         type_ds: SymbolOrdered,
         flag: VariableKind = VariableKind.IMMUTABLE,
     ) -> BaseDataContainer | ErrorHandler:
-
         # quantum variables are, at least for now, always appendable and thus mutable
         if isquantum(var_name) and isquantum(type_name):
             return AppendableVariable(var_name, type_name, type_ds, True)
 
         if not isquantum(var_name) and not isquantum(type_name):
-
             match flag:
-
                 # constant, at least for now, cannot be quantum
                 case VariableKind.CONSTANT:
                     return ConstantData(var_name, type_name, type_ds)
@@ -330,20 +322,14 @@ class ImmutableVariable(BaseDataContainer):
         *args: Any,
         **kwargs: SymbolOrdered,
     ) -> None | ErrorHandler:
-
         if not self._assigned:
-
             if len(args) == len(self._ds):
-
                 for k, d in zip(args, self._ds):
-
                     if not self._check_assign_ds_vals(k, d):
                         return ContainerVarError(self.name)
 
             elif len(kwargs) == len(self._ds):
-
                 for k, v in kwargs.items():
-
                     if not self._check_assign_ds_args_vals(Symbol(k), v):
                         return ContainerVarError(self.name)
 
@@ -391,18 +377,13 @@ class MutableVariable(BaseDataContainer):
     def assign(
         self, *args: Any, **kwargs: dict[WorkingData, WorkingData | BaseDataContainer]
     ) -> None | ErrorHandler:
-
         if len(args) == len(self._ds):
-
             for k, d in zip(args, self._ds):
-
                 if not self._check_assign_ds_vals(k, d):
                     return ContainerVarError(self.name)
 
         elif len(kwargs) == len(self._ds):
-
             for k, v in kwargs.items():
-
                 if not self._check_assign_ds_args_vals(Symbol(k), v):
                     return ContainerVarError(self.name)
 
@@ -451,18 +432,13 @@ class AppendableVariable(BaseDataContainer):
         *args: Any,
         **kwargs: SymbolOrdered,
     ) -> None | ErrorHandler:
-
         if len(args) == len(self._ds):
-
             for k, d in zip(args, self._ds):
-
                 if not self._check_assign_ds_vals(k, d):
                     return ContainerVarError(self.name)
 
         elif len(kwargs) == len(self._ds):
-
             for k, v in kwargs.items():
-
                 if not self._check_assign_ds_args_vals(Symbol(k), v):
                     return ContainerVarError(self.name)
 

--- a/python/src/hhat_lang/core/error_handlers/errors.py
+++ b/python/src/hhat_lang/core/error_handlers/errors.py
@@ -36,6 +36,8 @@ class ErrorCodes(Enum):
     HEAP_INVALID_KEY_ERROR = auto()
     HEAP_EMPTY_ERROR = auto()
 
+    SYMBOLTABLE_INVALID_KEY_ERROR = auto()
+
     INVALID_QUANTUM_COMPUTED_RESULT = auto()
 
     INSTR_NOTFOUND_ERROR = auto()
@@ -302,6 +304,24 @@ class HeapInvalidKeyError(ErrorHandler):
 
     def __call__(self) -> str:
         return f"[[{self.__class__.__name__}]]: key '{self._key}' is invalid."
+
+
+class SymbolTableInvalidKeyError(ErrorHandler):
+    def __init__(self, key: Any, key_type: str):
+        super().__init__(ErrorCodes.SYMBOLTABLE_INVALID_KEY_ERROR)
+        self._key = key
+        self._key_type = key_type
+
+    @classmethod
+    def Type(cls) -> str:
+        return "type"
+
+    @classmethod
+    def Fn(cls) -> str:
+        return "fn"
+
+    def __call__(self) -> str:
+        return f"[[{self.__class__.__name__}]]: key '{self._key}' is invalid for {self._key_type}."
 
 
 class InvalidQuantumComputedResult(ErrorHandler):

--- a/python/src/hhat_lang/core/execution/abstract_program.py
+++ b/python/src/hhat_lang/core/execution/abstract_program.py
@@ -8,7 +8,7 @@ from hhat_lang.core.data.core import WorkingData
 from hhat_lang.core.error_handlers.errors import ErrorHandler
 from hhat_lang.core.execution.abstract_base import BaseEvaluator
 from hhat_lang.core.lowlevel.abstract_qlang import BaseLowLevelQLang
-from hhat_lang.core.memory.core import BaseStack, IndexManager
+from hhat_lang.core.memory.core import BaseStack, IndexManager, SymbolTable
 
 
 class BaseProgram(ABC):
@@ -18,6 +18,7 @@ class BaseProgram(ABC):
     _executor: BaseEvaluator
     _qlang: BaseLowLevelQLang
     _qstack: BaseStack
+    _symbol: SymbolTable
 
     @abstractmethod
     def run(self) -> Any | ErrorHandler: ...

--- a/python/src/hhat_lang/core/memory/core.py
+++ b/python/src/hhat_lang/core/memory/core.py
@@ -143,7 +143,6 @@ class IndexManager:
         """
 
         if (self._num_allocated + num_idxs) <= self._max_num_index:
-
             if var_name not in self._resources:
                 self._resources[var_name] = num_idxs
                 return None
@@ -164,7 +163,6 @@ class IndexManager:
             return IndexInvalidVarError(var_name)
 
         match x := self._alloc_idxs(num_idxs):
-
             case deque():
                 if not self._has_var(var_name):
                     return IndexInvalidVarError(var_name=var_name)
@@ -275,7 +273,6 @@ class SymbolTable:
 
 
 class BaseMemoryManager(ABC):
-
     _idx: IndexManager
     _stack: BaseStack
     _heap: BaseHeap

--- a/python/src/hhat_lang/core/types/builtin_base.py
+++ b/python/src/hhat_lang/core/types/builtin_base.py
@@ -140,8 +140,3 @@ def int_to_uN(
 
     # something else?
     raise NotImplementedError()
-
-
-# classical
-
-# quantum

--- a/python/src/hhat_lang/core/types/builtin_base.py
+++ b/python/src/hhat_lang/core/types/builtin_base.py
@@ -106,12 +106,10 @@ class BuiltinSingleDS(BaseTypeDataStructure):
 def int_to_uN(
     ds: BuiltinSingleDS, data: CoreLiteral | BaseDataContainer
 ) -> CoreLiteral | BaseDataContainer | ErrorHandler:
-
     if ds.bitsize is not None:
         max_value = 1 << ds.bitsize.size
 
         if isinstance(data, CoreLiteral):
-
             if data < 0:
                 return CastNegToUnsignedError(data, ds.members[0][1])
 
@@ -124,7 +122,6 @@ def int_to_uN(
         if isinstance(data, BaseDataContainer):
             val = data.get()
             if data.type in int_types:
-
                 match val:
                     case ErrorHandler():
                         return val

--- a/python/src/hhat_lang/core/types/builtin_types.py
+++ b/python/src/hhat_lang/core/types/builtin_types.py
@@ -13,7 +13,7 @@ from hhat_lang.core.types.builtin_base import BuiltinSingleDS
 # classical #
 # -----------#
 
-Int = BuiltinSingleDS(Symbol("int"))
+Int = BuiltinSingleDS(Symbol("int"), Size(64))
 Bool = BuiltinSingleDS(Symbol("bool"), Size(8))
 U16 = BuiltinSingleDS(Symbol("u16"), Size(16))
 U32 = BuiltinSingleDS(Symbol("u32"), Size(32))

--- a/python/src/hhat_lang/core/types/core.py
+++ b/python/src/hhat_lang/core/types/core.py
@@ -47,7 +47,6 @@ class SingleDS(BaseTypeDataStructure):
     def add_member(
         self, member_type: BaseTypeDataStructure, _member_name: None = None
     ) -> SingleDS | ErrorHandler:
-
         if not is_valid_member(self, member_type.name):
             return TypeQuantumOnClassicalError(member_type.name, self.name)
 
@@ -123,10 +122,8 @@ class StructDS(BaseTypeDataStructure):
     def add_member(
         self, member_type: BaseTypeDataStructure, member_name: Symbol | CompositeSymbol
     ) -> StructDS | ErrorHandler:
-
         # check if type and name are consistent, i.e. both quantum or classical
         if has_same_paradigm(member_type, member_name):
-
             if is_valid_member(self, member_type.name):
                 self._type_container[member_name] = member_type.name
                 return self
@@ -146,7 +143,6 @@ class StructDS(BaseTypeDataStructure):
 
         if len(args) == len(self._type_container):
             for k, (g, c) in zip(args, self._type_container.items()):
-
                 if k.type == c:
                     container[g] = k
 
@@ -155,7 +151,6 @@ class StructDS(BaseTypeDataStructure):
 
         if len(kwargs) == len(self._type_container):
             for n, (k, v) in enumerate(kwargs.items()):
-
                 if k in self._type_container:
                     container[k] = v
 

--- a/python/src/hhat_lang/core/types/resolve_sizes.py
+++ b/python/src/hhat_lang/core/types/resolve_sizes.py
@@ -12,7 +12,6 @@ def _size_resolver():
 
 def _qsize_resolver(ds: BaseTypeDataStructure, table: TypeTable) -> int | None:
     if ds.qsize is not None:
-
         if ds.qsize.max is None:
             qsize_max = 0
 

--- a/python/src/hhat_lang/dialects/heather/code/ast.py
+++ b/python/src/hhat_lang/dialects/heather/code/ast.py
@@ -50,7 +50,7 @@ class OnlyValue(Node):
 
 class Modifier(Node):
     def __init__(self, *modifiers: ArgValuePair):
-        self._values = modifiers
+        self._value = modifiers
         self._name = self.__class__.__name__
 
 
@@ -106,6 +106,11 @@ class Expr(Node):
         self._name = self.__class__.__name__
 
 
+class Return(Expr):
+    def __init__(self, *expr: Expr):
+        super().__init__(*expr)
+
+
 class Declare(Node):
     def __init__(self, var_name: Id, var_type: TypeType):
         self._value = (var_name, var_type)
@@ -130,8 +135,8 @@ class DeclareAssign(Node):
 
 
 class CallArgs(Node):
-    def __init__(self, *args: ArgValuePair | OnlyValue):
-        self._values = args
+    def __init__(self, *args: ArgValuePair | OnlyValue | Call):
+        self._value = args
         self._name = self.__class__.__name__
 
 
@@ -143,7 +148,7 @@ class Call(Node):
 
 class MethodCallArgs(Node):
     def __init__(self, *args: ArgValuePair | OnlyValue):
-        self._values = args
+        self._value = args
         self._name = self.__class__.__name__
 
 
@@ -154,7 +159,7 @@ class MethodCall(Node):
 
 
 class InsideOption(Node):
-    def __init__(self, option: Expr, body: Body):
+    def __init__(self, option: Call | Array | TypeType, body: Body):
         self._value = (option, body)
         self._name = self.__class__.__name__
 
@@ -190,7 +195,7 @@ class ArgTypePair(Node):
 
 class FnArgs(Node):
     def __init__(self, *args: ArgTypePair):
-        self._values = args
+        self._value = args
         self._name = self.__class__.__name__
 
 
@@ -279,7 +284,7 @@ class Body(Node):
     """
 
     def __init__(self, *body: BodyType):
-        self._values = body
+        self._value = body
         self._name = self.__class__.__name__
 
 
@@ -306,7 +311,7 @@ class Program(Node):
 
         self._value = ()
 
-        if imports and body:
+        if imports:
             self._value += (imports,)
 
         if body:

--- a/python/src/hhat_lang/dialects/heather/code/ast.py
+++ b/python/src/hhat_lang/dialects/heather/code/ast.py
@@ -175,7 +175,7 @@ class CallWithBodyOptions(Node):
         self._name = self.__class__.__name__
 
 
-class CallWithArgsBodyOptions(Node):
+class CallWithArgsOptions(Node):
     def __init__(self, *arg_options: InsideOption, caller: TypeType):
         self._value = (caller, arg_options)
         self._name = self.__class__.__name__

--- a/python/src/hhat_lang/dialects/heather/code/ir_builder.py
+++ b/python/src/hhat_lang/dialects/heather/code/ir_builder.py
@@ -63,7 +63,6 @@ from hhat_lang.dialects.heather.code.simple_ir_builder.builder import (
     define_id,
     define_literal,
 )
-
 # for now just a simple IR for the interpreter suffices
 from hhat_lang.dialects.heather.code.simple_ir_builder.ir import IR
 from hhat_lang.dialects.heather.parsing.imports import (

--- a/python/src/hhat_lang/dialects/heather/code/ir_builder.py
+++ b/python/src/hhat_lang/dialects/heather/code/ir_builder.py
@@ -107,7 +107,6 @@ def _build_modifier(code: Modifier) -> tuple[tuple[Symbol, Any], ...]:
     mods = ()
 
     for mod in code.value:
-
         arg, value = _build_argvaluepair(mod)
         mods += ((arg, value),)
 
@@ -205,7 +204,6 @@ def _build_typedef(code: TypeDef) -> Any:
 
 def _build_typeimport(code: TypeImport) -> Any:
     for k in code:
-
         match k:
             case Id():
                 pass
@@ -223,7 +221,6 @@ def _build_fnimport(code: FnImport) -> Any:
 
 def _build_imports(code: Imports) -> Any:
     for k in code:
-
         match k:
             case TypeImport():
                 return _build_typeimport(k)
@@ -237,7 +234,6 @@ def _build_imports(code: Imports) -> Any:
 
 def _build_body(code: Body) -> Any:
     for k in code:
-
         _build_bodytype(k)
 
 
@@ -250,7 +246,6 @@ def _build_valuetype(code: ValueType) -> Any:
     """Build based on the `ValueType` type descriptor."""
 
     match tmp := code:
-
         case Id():
             return _build_id(tmp)
 
@@ -326,9 +321,7 @@ def _build_bodytype(code: BodyType) -> Any:
 
 def build_typetable(code: AST) -> Any:
     for k in code:
-
         match k:
-
             case Id():
                 pass
 
@@ -433,9 +426,7 @@ def build_main(code: AST) -> Any:
     ir = IR()
 
     for k in code:
-
         match k:
-
             case Imports():
                 res = parse_imports(k)
 

--- a/python/src/hhat_lang/dialects/heather/code/simple_ir_builder/builder.py
+++ b/python/src/hhat_lang/dialects/heather/code/simple_ir_builder/builder.py
@@ -52,7 +52,6 @@ def define_argvaluepair(code: ArgValuePair) -> tuple[Symbol, Any]:
 
 def define_valuetype(code: ValueType) -> Any:
     match code:
-
         case Id():
             return define_id(code)
 

--- a/python/src/hhat_lang/dialects/heather/code/simple_ir_builder/ir.py
+++ b/python/src/hhat_lang/dialects/heather/code/simple_ir_builder/ir.py
@@ -1,110 +1,379 @@
 """
-Simple IR implementation. Intended to be simple for AST conversion and
-readiness for the evaluator.
+Define the classes to handle ``IR`` structure, from instructions, instructions
+blocks, to the ``IR`` holder.
 """
 
 from __future__ import annotations
 
-import uuid
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from enum import Enum, auto
 from typing import Any, Iterable
 
-from hhat_lang.core.code.ast import AST
-from hhat_lang.core.code.ir import (
-    ArgsIR,
-    BaseFnIR,
-    BaseIR,
-    BlockIR,
-    InstrIR,
-    InstrIRFlag,
-)
-from hhat_lang.core.data.core import (
-    CompositeLiteral,
-    CompositeSymbol,
-    CoreLiteral,
-    Symbol,
-)
+from hhat_lang.core.data.core import Symbol, WorkingData, CoreLiteral, CompositeSymbol
 
 
-class IRInstr(InstrIR):
-    def __init__(self, name: Symbol | CompositeSymbol, args: IRArgs, flag: InstrIRFlag):
-        if (
-            isinstance(name, (Symbol, CompositeSymbol))
-            and isinstance(args, IRArgs)
-            and isinstance(flag, InstrIRFlag)
-        ):
-            self._name = name
-            self._args = args
-            self._flag = flag
+# FIXME: quick fix for now, before the new IR is ready
+class FnIR(): pass
+class IRInstr(): pass
 
 
-class IRArgs(ArgsIR):
+class IRFlag(Enum):
+    """
+    Used to identify the ``IRBaseInstr`` child class purpose. Ex: a ``CallInstr``
+    class is defined with its name as ``IRFlag.CALL``.
+    """
+
+    NULL = auto()
+    CALL = auto()
+    CAST = auto()
+    ASSIGN = auto()
+    DECLARE = auto()
+    DECLARE_ASSIGN = auto()
+    ARGS = auto()
+    OPTION = auto()
+    COND = auto()
+    MATCH = auto()
+    CALL_WITH_BODY = auto()
+    CALL_WITH_OPTION = auto()
+    RETURN = auto()
+
+
+class BlockRef:
+    """
+    Define a block reference to be used by the ``IR`` object on lookups for existing
+    or new blocks.
+    """
+
+    name: str
+
+    def __init__(self, *instrs: Any):
+        self.name = str(hash(instrs))
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, BlockRef | IRBlock):
+            return self.name == other.name
+
+        if isinstance(other, str):
+            return self.name == other
+
+        return False
+
+    def __repr__(self) -> str:
+        return f"#{self.name[-8:]}"
+
+
+class IRBlock:
+    """
+    It contains a tuple with instructions (``IRBaseInstr`` child classes) and
+    block references (``BlockRef``). Use it to aggregate multiple instructions or
+    references.
+    """
+
+    instrs: tuple | tuple[IRBaseInstr | BlockRef, ...]
+    name: BlockRef
+
+    def __init__(self, *instrs: IRBaseInstr | BlockRef):
+        self.instrs = instrs
+        self.name = BlockRef(*instrs)
+
+    @classmethod
+    def gen_block(cls, *instrs: IRBaseInstr | IRBlock) -> tuple[BlockRef, IRBlock]:
+        """Generate a new block, returning new block's name (BlockRef) and new block's object"""
+
+        new_block = IRBlock(*instrs)
+        return new_block.name, new_block
+
+    def add_instrs(self, *instrs: IRBaseInstr | IRBlock) -> None:
+        self.instrs += instrs
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.instrs))
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, IRBlock):
+            return self.instrs == other.instrs and self.name == other.name
+
+        return False
+
+    def __len__(self) -> int:
+        return len(self.instrs)
+
+    def __iter__(self) -> Iterable:
+        yield from self.instrs
+
+    def __repr__(self) -> str:
+        content = ""
+        total_instrs = len(str(len(self)))
+
+        for n, k in enumerate(self.instrs):
+            content += f"\n      {'0' * (total_instrs - len(str(n)) + 1) + str(n+1)} {k}"
+
+        return f"      block:{content}\n"
+
+
+##############################
+# IR INSTRUCTION DEFINITIONS #
+##############################
+
+class IRBaseInstr(ABC):
+    """
+    Abstract class to create instructions. It must contain a name (str or
+    ``IRFlag`` attribute), and arguments that may vary according to child
+    instruction. A block reference dictionary is created to hold every new
+    block creation, so the IR can account for it later.
+    """
+
+    INSTR: IRFlag
+    name: str
+    args: tuple | tuple[WorkingData | BlockRef | IRBaseInstr, ...]
+    block_refs: dict | dict[BlockRef, IRBlock]
+
     def __init__(
-        self, *args: Symbol | CompositeSymbol | CoreLiteral | CompositeLiteral
-    ):
-        if (
-            all(
-                isinstance(k, (Symbol, CompositeSymbol, CoreLiteral, CompositeLiteral))
-                for k in args
-            )
-            or len(args) == 0
-        ):
-            self._args = args
-
-
-class IRBlock(BlockIR):
-    def __init__(self):
-        self._instrs = tuple()
-        self.name = str(uuid.uuid4())
-
-    def add_instr(self, instr: IRInstr | IRBlock) -> None:
-        if isinstance(instr, IRInstr | IRBlock):
-            self._instrs += (instr,)
-
-
-################
-# IR BASE CODE #
-################
-
-
-def compile_to_ir(code: AST) -> IR:
-    raise NotImplementedError()
-
-
-class FnIR(BaseFnIR):
-    def __init__(self):
-        self._data = dict()
-
-    def push(self, *ags: Any, **kwargs: Any) -> Any:
-        pass
-
-    def get(self, item: Any) -> Any:
-        pass
-
-    def __setitem__(self, key: Any, value: Any) -> None:
-        pass
-
-    def __getitem__(self, key: Symbol | CompositeSymbol) -> Any:
-        pass
-
-    def __contains__(self, item: Any) -> bool:
-        raise NotImplementedError()
-
-
-class IR(BaseIR):
-    """
-    The IR class that contains all the relevant code to be evaluated, including
-    types, functions and `main` body. An evaluator class must use this one to
-    execute classical instructions.
-    """
-
-    def __init__(self):
-        super().__init__()
-
-    def add_fn(
         self,
-        *,
-        fn_name: Symbol,
-        fn_type: Symbol | CompositeSymbol,
-        fn_args: Any,
-        body: IRBlock,
-    ) -> None: ...
+        *args: WorkingData | IRBlock | BlockRef | IRBaseInstr,
+        name: str | IRFlag
+    ):
+        self.name = name.name if isinstance(name, IRFlag) else name
+        self.args = ()
+        self.block_refs = dict()
+
+        for k in args:
+            self.add(k)
+
+    @property
+    def instr(self) -> IRFlag:
+        return self.INSTR
+
+    @property
+    def get_refs(self) -> dict[BlockRef, IRBlock]:
+        return deepcopy(self.block_refs)
+
+    def add(self, data: WorkingData | IRBlock | BlockRef | IRBaseInstr) -> None:
+        match data:
+            case WorkingData() | BlockRef():
+                self.args += data,
+
+            case IRBaseInstr():
+                ref, block = IRBlock.gen_block(data)
+                self.block_refs[ref] = block
+                self.args += ref,
+
+            case IRBlock():
+                self.args += data.name,
+
+                if data.name not in self.block_refs:
+                    self.block_refs[data.name] = data
+
+            case _:
+                raise ValueError(
+                    f"something went wrong when adding IR instruction for {data} ({type(data)})"
+                )
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.args))
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, IRBaseInstr):
+            return self.args == other.args and self.name == other.name
+
+        return False
+
+    def __iter__(self) -> Iterable:
+        yield from self.args
+
+    def __repr__(self):
+        content = ", ".join(str(k) for k in self)
+        return f"{self.name}({content})"
+
+    @abstractmethod
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IRArgs(IRBaseInstr):
+    INSTR = IRFlag.ARGS
+
+    def __init__(self, *args: WorkingData | IRBlock | BlockRef):
+        super().__init__(*args, name=IRFlag.ARGS)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IRCall(IRBaseInstr):
+    INSTR = IRFlag.CALL
+
+    def __init__(
+        self,
+        caller: Symbol | CompositeSymbol,
+        args: IRArgs,
+    ):
+        super().__init__(caller, args, name=IRFlag.CALL)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IRCast(IRBaseInstr):
+    INSTR = IRFlag.CAST
+
+    def __init__(
+        self,
+        cast_data: WorkingData | IRBlock | BlockRef,
+        to_type: Symbol | CompositeSymbol
+    ):
+        super().__init__(cast_data, to_type, name=IRFlag.CAST)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IRAssign(IRBaseInstr):
+    INSTR = IRFlag.ASSIGN
+
+    def __init__(self, var: Symbol, value: WorkingData | IRBlock | BlockRef):
+        super().__init__(var, value, name=IRFlag.ASSIGN)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IRDeclare(IRBaseInstr):
+    INSTR = IRFlag.DECLARE
+
+    def __init__(self, var: Symbol, var_type: Symbol | CompositeSymbol):
+        super().__init__(var, var_type, name=IRFlag.DECLARE)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IRDeclareAssign(IRBaseInstr):
+    INSTR = IRFlag.DECLARE_ASSIGN
+
+    def __init__(
+        self,
+        var: Symbol,
+        var_type: Symbol | CompositeSymbol,
+        value: WorkingData
+    ):
+        super().__init__(var, var_type, value, name=IRFlag.DECLARE_ASSIGN)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IRCallWithBody(IRBaseInstr):
+    INSTR = IRFlag.CALL_WITH_BODY
+
+    def __init__(
+        self,
+        caller: Symbol | CompositeSymbol,
+        args: IRArgs,
+        body: IRBlock | BlockRef
+    ):
+        super().__init__(caller, args, body, name=IRFlag.CALL_WITH_BODY)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IROption(IRBaseInstr):
+    INSTR = IRFlag.OPTION
+
+    def __init__(
+        self,
+        option: WorkingData | IRBlock | BlockRef,
+        body: WorkingData | IRBlock | BlockRef,
+    ):
+        super().__init__(option, body, name=IRFlag.OPTION)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class IRCallWithOption(IRBaseInstr):
+    INSTR = IRFlag.CALL_WITH_OPTION
+
+    def __init__(
+        self,
+        caller: Symbol | CompositeSymbol,
+        args: IRArgs,
+        *options: tuple[IROption, ...]
+    ):
+        super().__init__(caller, args, *options, name=IRFlag.CALL_WITH_BODY)
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+#################
+# IR ROOT CLASS #
+#################
+
+class IR:
+    """
+    This class creates a new intermediate representation object that should
+    hold the whole program code. The code can be only in terms of ``WorkingData``
+    and ``IRBlock`` objects. An interpreter or compiler should evaluate its content.
+
+    **Note**: function definitions must be created as separate ``IRBlock`` objects
+    and populated in ``MemoryManager`` for further call/reference during evaluation.
+
+    **Note2**: type definitions must be transformed from AST directly into
+    ``BaseTypeDataStructure``.
+    """
+
+    table: dict[BlockRef, IRBlock]
+
+    def __init__(self):
+        self.table = dict()
+
+    def add_ref(self, ref: BlockRef, code: IRBlock) -> None:
+        self.table[ref] = code
+
+    def add_new_block(self, block: IRBlock) -> None:
+        if block.name not in self.table:
+            self.add_ref(block.name, block)
+
+            # iterate over each instruction to check for new blocks
+            for k in block:
+
+                match k:
+
+                    # blocks will have the same check as above
+                    case IRBlock():
+                        if k.name not in self.table:
+                            self.add_ref(k.name, k)
+
+                    # instructions will have a check on their block_refs
+                    case IRBaseInstr():
+
+                        # iterating over all the blocks in the instruction
+                        for p, q in k.block_refs.items():
+
+                            if p not in self.table:
+                                self.add_ref(p, q)
+
+    def __iter__(self) -> Iterable:
+        yield from self.table.items()
+
+    def __repr__(self) -> str:
+        content = ""
+        for k, v in self:
+            content += f"  {k}\n{v}\n"
+        return f"[\n{content}]"
+
+
+if __name__ == "__main__":
+    ir1 = IR()
+    i1 = IRDeclare(var=Symbol("@q"), var_type=Symbol("@u3"))
+    i2 = IRAssign(var=Symbol("@q"), value=CoreLiteral(value="@1", lit_type="@int"))
+    i3 = IRCall(caller=Symbol("@redim"), args=IRArgs(Symbol("@q")))
+    block1 = IRBlock(i1, i2, i3)
+    ir1.add_new_block(block1)
+    print(ir1)

--- a/python/src/hhat_lang/dialects/heather/code/simple_ir_builder/old_ir.py
+++ b/python/src/hhat_lang/dialects/heather/code/simple_ir_builder/old_ir.py
@@ -1,0 +1,111 @@
+"""
+Simple IR implementation. Intended to be simple for AST conversion and
+readiness for the evaluator.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Iterable
+
+from hhat_lang.core.code.ast import AST
+from hhat_lang.core.code.ir import (
+    ArgsIR,
+    BaseFnIR,
+    BaseIR,
+    BlockIR,
+    InstrIR,
+    InstrIRFlag,
+)
+from hhat_lang.core.data.core import (
+    CompositeLiteral,
+    CompositeSymbol,
+    CoreLiteral,
+    Symbol,
+)
+
+
+class IRInstr(InstrIR):
+    def __init__(self, name: Symbol | CompositeSymbol, args: IRArgs, flag: InstrIRFlag):
+        if (
+            isinstance(name, (Symbol, CompositeSymbol))
+            and isinstance(args, IRArgs)
+            and isinstance(flag, InstrIRFlag)
+        ):
+            self._name = name
+            self._args = args
+            self._flag = flag
+
+
+class IRArgs(ArgsIR):
+    def __init__(
+        self, *args: Symbol | CompositeSymbol | CoreLiteral | CompositeLiteral
+    ):
+        if (
+            all(
+                isinstance(k, (Symbol, CompositeSymbol, CoreLiteral, CompositeLiteral))
+                for k in args
+            )
+            or len(args) == 0
+        ):
+            self._args = args
+
+
+class IRBlock(BlockIR):
+    def __init__(self):
+        self._instrs = tuple()
+        self.name = str(uuid.uuid4())
+
+    def add_instr(self, instr: IRInstr | IRBlock) -> IRBlock:
+        if isinstance(instr, IRInstr | IRBlock):
+            self._instrs += (instr,)
+        return self
+
+
+################
+# IR BASE CODE #
+################
+
+
+def compile_to_ir(code: AST) -> IR:
+    raise NotImplementedError()
+
+
+class FnIR(BaseFnIR):
+    def __init__(self):
+        self._data = dict()
+
+    def push(self, *ags: Any, **kwargs: Any) -> Any:
+        pass
+
+    def get(self, item: Any) -> Any:
+        pass
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        pass
+
+    def __getitem__(self, key: Symbol | CompositeSymbol) -> Any:
+        pass
+
+    def __contains__(self, item: Any) -> bool:
+        raise NotImplementedError()
+
+
+class IR(BaseIR):
+    """
+    The IR class that contains all the relevant code to be evaluated, including
+    types, functions and `main` body. An evaluator class must use this one to
+    execute classical instructions.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def add_fn(
+        self,
+        *,
+        fn_name: Symbol,
+        fn_type: Symbol | CompositeSymbol,
+        fn_args: Any,
+        body: IRBlock,
+    ) -> None: ...

--- a/python/src/hhat_lang/dialects/heather/code/ssa_ir_builder/ir.py
+++ b/python/src/hhat_lang/dialects/heather/code/ssa_ir_builder/ir.py
@@ -41,7 +41,6 @@ class IRModifier:
 
         # check whether amods (mod arguments) is not empty:
         if amods:
-
             for n, p in enumerate(amods):
                 if isinstance(p, (Symbol, CompositeSymbol, SSA)):
                     self._mods[n] = p
@@ -51,7 +50,6 @@ class IRModifier:
 
         # check whether kmods (mod key-value pairs) is not empty instead:
         elif kmods:
-
             for k, v in kmods.items():
                 if isinstance(k, Symbol) and isinstance(
                     v, (Symbol, CompositeSymbol, SSA, CoreLiteral)
@@ -267,8 +265,7 @@ class IRVar:
 
             case _:
                 raise ValueError(
-                    f"IRVar only accepts Symbol, SSA, SSAPhi or IRModifier."
-                    f" ({name} ({type(name)}))"
+                    f"IRVar only accepts Symbol, SSA, SSAPhi or IRModifier. ({name} ({type(name)}))"
                 )
 
         raise ValueError("IRVar cannot accept a different symbol (variable).")

--- a/python/src/hhat_lang/dialects/heather/grammar/grammar.peg
+++ b/python/src/hhat_lang/dialects/heather/grammar/grammar.peg
@@ -27,7 +27,7 @@ id_composite_value          = ( '[' id ']' ) / id
 main                        = 'main' body
 
 body                        = '{' (declare / assign / declareassign / expr)* '}'
-expr                        = cast / callwithargsbodyoptions / callwithbodyoptions / callwithbody / call / array / id / literal
+expr                        = cast / callwithargsoptions / callwithbodyoptions / callwithbody / call / array / id / literal
 declare                     = simple_id modifier? ':' id
 assign                      = id '=' expr
 declareassign               = simple_id modifier? ':' id '=' expr
@@ -38,7 +38,7 @@ callargs                    = simple_id ':' valonly
 valonly                     = array / literal / id
 option                      = (( call / array / id ) ':' body)
 callwithbodyoptions         = id '(' args* ')' '{' option+ '}'
-callwithargsbodyoptions     = id '(' option+ ')'
+callwithargsoptions     = id '(' option+ ')'
 callwithbody                = id '(' args* ')' body
 
 array                       = '[' ( literal / composite_id_with_closure / id )* ']'

--- a/python/src/hhat_lang/dialects/heather/grammar/grammar.peg
+++ b/python/src/hhat_lang/dialects/heather/grammar/grammar.peg
@@ -17,17 +17,17 @@ unionmember                 = typemember / typestruct / typeenum
 type_trait                  = 'trait' id '{' fns* '}'
 typespace                   = 'typespace' ( trait_id / id ) '{' fns* '}'
 
-fns                         = 'fn' simple_id fnargs id? body
+fns                         = 'fn' simple_id fnargs id? fn_body
 fnargs                      = '(' argtype* ')'
 argtype                     = simple_id ':' id_composite_value
 fn_body                     = '{' (declare / assign / declareassign / return / expr)* '}'
-return                      = "=" expr
+return                      = "::" expr
 id_composite_value          = ( '[' id ']' ) / id
 
 main                        = 'main' body
 
 body                        = '{' (declare / assign / declareassign / expr)* '}'
-expr                        = cast / call / callwithbody / callwithbodyoptions / callwithargsbodyoptions / array / id / literal
+expr                        = cast / callwithargsbodyoptions / callwithbodyoptions / callwithbody / call / array / id / literal
 declare                     = simple_id modifier? ':' id
 assign                      = id '=' expr
 declareassign               = simple_id modifier? ':' id '=' expr
@@ -36,15 +36,16 @@ call                        = (trait_id '.')? id '(' args* ')'
 args                        = callargs / call / valonly
 callargs                    = simple_id ':' valonly
 valonly                     = array / literal / id
-callwithbodyoptions         = id '(' args* ')' body
-callwithargsbodyoptions     = id '(' (expr body)+ ')'
-callwithbody                = id body
+option                      = (( call / array / id ) ':' body)
+callwithbodyoptions         = id '(' args* ')' '{' option+ '}'
+callwithargsbodyoptions     = id '(' option+ ')'
+callwithbody                = id '(' args* ')' body
 
 array                       = '[' ( literal / composite_id_with_closure / id )* ']'
 
 simple_id                   = r'@?[a-zA-Z][a-zA-Z0-9\-_]*'
 composite_id                = simple_id ('.' simple_id)+
-composite_id_with_closure   = ( simple_id / composite_id ) '.' '{' ( simple_id / composite_id / composite_id_with_closure ) '}'
+composite_id_with_closure   = ( composite_id / simple_id ) '.' '{' ( composite_id_with_closure / composite_id / simple_id )+ '}'
 modifier                    = '<' ( valonly+ / callargs+ ) '>'
 trait_id                    = simple_id '#' id
 id                          = ( composite_id / simple_id ) modifier?

--- a/python/src/hhat_lang/dialects/heather/interpreter/quantum/program.py
+++ b/python/src/hhat_lang/dialects/heather/interpreter/quantum/program.py
@@ -42,7 +42,7 @@ from hhat_lang.core.error_handlers.errors import ErrorHandler
 from hhat_lang.core.execution.abstract_base import BaseEvaluator
 from hhat_lang.core.execution.abstract_program import BaseProgram
 from hhat_lang.core.lowlevel.abstract_qlang import BaseLowLevelQLang
-from hhat_lang.core.memory.core import BaseStack, IndexManager, Stack
+from hhat_lang.core.memory.core import BaseStack, IndexManager, Stack, SymbolTable
 from hhat_lang.dialects.heather.code.simple_ir_builder.ir import IRBlock
 
 # TODO: the imports below must come from the config file, not hardcoded
@@ -59,9 +59,10 @@ class Program(BaseProgram):
         idx: IndexManager,
         block: IRBlock,
         executor: BaseEvaluator,
+        symboltable: SymbolTable,
         qlang: Type[  # type: ignore [type-arg]
             BaseLowLevelQLang[
-                WorkingData, IRBlock | BlockIR, IndexManager, BaseEvaluator, Stack
+                WorkingData, IRBlock | BlockIR, IndexManager, BaseEvaluator, Stack, SymbolTable
             ]
         ],
     ):
@@ -75,8 +76,9 @@ class Program(BaseProgram):
             self._block = block
             self._executor = executor
             self._qstack = Stack()
+            self._symbol = symboltable
             self._qlang = qlang(
-                self._qdata, self._block, self._idx, self._executor, self._qstack
+                self._qdata, self._block, self._idx, self._executor, self._qstack, self._symbol
             )
 
         else:

--- a/python/src/hhat_lang/dialects/heather/parsing/visitor.py
+++ b/python/src/hhat_lang/dialects/heather/parsing/visitor.py
@@ -6,20 +6,35 @@ from hhat_lang.core.code.ast import AST
 from hhat_lang.dialects.heather.code.ast import (
     ArgTypePair,
     ArgValuePair,
+    Assign,
+    Body,
+    Call,
+    CallArgs,
+    CallWithArgsBodyOptions,
+    CallWithBody,
+    CallWithBodyOptions,
+    Cast,
     CompositeId,
     CompositeIdWithClosure,
     CompositeLiteral,
+    Declare,
+    DeclareAssign,
     EnumTypeMember,
+    Expr,
+    FnArgs,
     FnDef,
     FnImport,
     Id,
     Imports,
+    InsideOption,
     Literal,
     Main,
     ManyTypeImport,
     ModifiedId,
     Modifier,
+    OnlyValue,
     Program,
+    Return,
     SingleTypeMember,
     TypeDef,
     TypeImport,
@@ -32,7 +47,7 @@ class ParserVisitor(PTNodeVisitor):
         imports: Imports | None = None
         types: tuple | tuple[TypeDef] = ()
         fns: tuple | tuple[FnDef] = ()
-        main: Main | None = None
+        main: Main | None = Main()
 
         for k in child:
             match k:
@@ -94,13 +109,85 @@ class ParserVisitor(PTNodeVisitor):
     def visit_enummember(self, _: NonTerminal, child: SemanticActionResults) -> AST:
         return EnumTypeMember(member_name=child[0])
 
+    def visit_fns(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        if len(child) == 4:
+            return FnDef(
+                fn_name=child[0], fn_type=child[2], args=child[1], body=child[-1]
+            )
+
+        return FnDef(
+            fn_name=child[0], fn_type=Id("null"), args=child[1], body=child[-1]
+        )
+
+    def visit_fnargs(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return FnArgs(*child)
+
+    def visit_argtype(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return ArgTypePair(arg_name=child[0], arg_type=child[1])
+
+    def visit_fn_body(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return Body(*child)
+
+    def visit_body(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return Body(*child)
+
+    def visit_declare(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return Declare(var_name=child[0], var_type=child[1])
+
+    def visit_assign(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return Assign(var_name=child[0], expr=child[1])
+
+    def visit_declareassign(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return DeclareAssign(var_name=child[0], var_type=child[1], expr=child[2])
+
+    def visit_return(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return Return(*child)
+
+    def visit_expr(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return Expr(*child)
+
+    def visit_cast(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return Cast(name=child[0], cast_to=child[1])
+
+    def visit_call(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        args = CallArgs(*[k for k in child[1:]])
+        return Call(caller=child[0], args=args)
+
+    def visit_trait_id(self, node: NonTerminal, child: SemanticActionResults) -> AST:
+        raise NotImplementedError()
+
+    def visit_args(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return child[0]
+
+    def visit_callargs(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return ArgValuePair(arg=child[0], value=child[1])
+
+    def visit_valonly(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return OnlyValue(value=child[0])
+
+    def visit_option(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return InsideOption(option=child[0], body=child[1])
+
+    def visit_callwithbody(self, _: NonTerminal, child: SemanticActionResults) -> AST:
+        return CallWithBody(caller=child[0], args=child[1], body=child[-1])
+
+    def visit_callwithbodyoptions(
+        self, _: NonTerminal, child: SemanticActionResults
+    ) -> AST:
+        return CallWithBodyOptions(*child[2:], caller=child[0], args=child[1])
+
+    def visit_callwithargsbodyoptions(
+        self, _: NonTerminal, child: SemanticActionResults
+    ) -> AST:
+        return CallWithArgsBodyOptions(*child[1:], caller=child[0])
+
     def visit_id_composite_value(
         self, _: NonTerminal, child: SemanticActionResults
     ) -> AST:
         """Get the value to form the type member for arguments and type definitions"""
         return child[0]
 
-    def visit_imports(self, node: NonTerminal, child: SemanticActionResults) -> AST:
+    def visit_imports(self, _: NonTerminal, child: SemanticActionResults) -> AST:
         """
         Take the tuple of optional type imports and function imports and place
         inside the `Imports` object, to be properly handled later by the type and
@@ -120,21 +207,26 @@ class ParserVisitor(PTNodeVisitor):
 
         return Imports(type_import=type_import, fn_import=fn_import)
 
-    def visit_typeimport(self, node: NonTerminal, child: SemanticActionResults) -> AST:
+    def visit_typeimport(self, _: NonTerminal, child: SemanticActionResults) -> AST:
         types: tuple | tuple[Id | CompositeId | CompositeIdWithClosure] = ()
 
         for k in child:
             match k:
+                case ManyTypeImport():
+                    types += tuple(p for p in k)
+
                 case Id() | CompositeId() | CompositeIdWithClosure():
                     types += (k,)
 
                 case _:
-                    raise ValueError("something went wrong when defining type import.")
+                    raise ValueError(
+                        f"something went wrong when defining type import: {k} ({type(k)})"
+                    )
 
         return TypeImport(type_list=types)
 
     def visit_fnimport(
-        self, node: NonTerminal | None, child: SemanticActionResults
+        self, _: NonTerminal | None, child: SemanticActionResults
     ) -> AST:
         fns: tuple | tuple[Id | CompositeId | CompositeIdWithClosure] = ()
 
@@ -149,13 +241,13 @@ class ParserVisitor(PTNodeVisitor):
         return FnImport(fn_list=fns)
 
     def visit_single_import(
-        self, node: NonTerminal | Terminal, child: SemanticActionResults
+        self, _: NonTerminal | Terminal, child: SemanticActionResults
     ) -> AST:
         """simply return the import AST"""
 
         return tuple(k for k in child)[0]
 
-    def visit_many_import(self, node: NonTerminal, child: SemanticActionResults) -> AST:
+    def visit_many_import(self, _: NonTerminal, child: SemanticActionResults) -> AST:
         return ManyTypeImport(*child)
 
     def visit_main(self, _: NonTerminal, child: SemanticActionResults) -> AST:
@@ -176,15 +268,13 @@ class ParserVisitor(PTNodeVisitor):
         name, *deps = tuple(k for k in child)
         return CompositeIdWithClosure(*deps, name=name)
 
-    def visit_id(
-        self, node: NonTerminal | Terminal, child: SemanticActionResults
-    ) -> AST:
+    def visit_id(self, _: NonTerminal | Terminal, child: SemanticActionResults) -> AST:
         if len(child) == 2 and isinstance(child[1], Modifier):
             return ModifiedId(name=child[0], modifier=child[1])
 
         return child[0]
 
-    def visit_modifier(self, node: NonTerminal, child: SemanticActionResults) -> AST:
+    def visit_modifier(self, _: NonTerminal, child: SemanticActionResults) -> AST:
         if all(isinstance(k, ArgValuePair) for k in child):
             return Modifier(*child)
 
@@ -192,27 +282,10 @@ class ParserVisitor(PTNodeVisitor):
             f"Modifier should have had ArgValuePair, got {set(type(k) for k in child)} instead."
         )
 
-    def visit_trait_id(self, node: NonTerminal, child: SemanticActionResults) -> AST:
-        raise NotImplementedError()
-
-    def visit_call(self, node: NonTerminal, child: SemanticActionResults) -> AST:
-        raise NotImplementedError()
-
-    def visit_args(self, node: NonTerminal, child: SemanticActionResults) -> AST:
-        raise NotImplementedError()
-
-    def visit_callargs(self, node: NonTerminal, child: SemanticActionResults) -> AST:
-        raise NotImplementedError()
-
-    def visit_valonly(self, node: NonTerminal, child: SemanticActionResults) -> AST:
-        raise NotImplementedError()
-
     def visit_array(self, node: NonTerminal, child: SemanticActionResults) -> AST:
         raise NotImplementedError()
 
-    def visit_composite_id(
-        self, node: NonTerminal, child: SemanticActionResults
-    ) -> AST:
+    def visit_composite_id(self, _: NonTerminal, child: SemanticActionResults) -> AST:
         if all(isinstance(k, Id) for k in child):
             return CompositeId(*child)
 

--- a/python/src/hhat_lang/dialects/heather/parsing/visitor.py
+++ b/python/src/hhat_lang/dialects/heather/parsing/visitor.py
@@ -10,7 +10,7 @@ from hhat_lang.dialects.heather.code.ast import (
     Body,
     Call,
     CallArgs,
-    CallWithArgsBodyOptions,
+    CallWithArgsOptions,
     CallWithBody,
     CallWithBodyOptions,
     Cast,
@@ -176,10 +176,10 @@ class ParserVisitor(PTNodeVisitor):
     ) -> AST:
         return CallWithBodyOptions(*child[2:], caller=child[0], args=child[1])
 
-    def visit_callwithargsbodyoptions(
+    def visit_callwithargsoptions(
         self, _: NonTerminal, child: SemanticActionResults
     ) -> AST:
-        return CallWithArgsBodyOptions(*child[1:], caller=child[0])
+        return CallWithArgsOptions(*child[1:], caller=child[0])
 
     def visit_id_composite_value(
         self, _: NonTerminal, child: SemanticActionResults

--- a/python/src/hhat_lang/low_level/quantum_lang/openqasm/v2/instructions.py
+++ b/python/src/hhat_lang/low_level/quantum_lang/openqasm/v2/instructions.py
@@ -40,7 +40,6 @@ class If(CInstr):
         transformed_instrs: tuple[str, ...] = ()
 
         for c, i in zip(cond_test, instrs):
-
             c_value: str
 
             match c:

--- a/python/src/hhat_lang/low_level/quantum_lang/openqasm/v2/qlang.py
+++ b/python/src/hhat_lang/low_level/quantum_lang/openqasm/v2/qlang.py
@@ -66,7 +66,6 @@ class LowLeveQLang(BaseLowLevelQLang):
         code_tuple: tuple[str, ...] = ()
 
         for member, data in var_data:
-
             match data:
                 case Symbol():
                     d_res = self.gen_var(data, executor=self._executor)
@@ -99,7 +98,6 @@ class LowLeveQLang(BaseLowLevelQLang):
                     raise NotImplementedError()
 
                 case InstrIR():
-
                     match res := self.gen_instrs(instr=data, executor=self._executor):
                         case Ok():
                             code_tuple += res.result()
@@ -116,7 +114,6 @@ class LowLeveQLang(BaseLowLevelQLang):
         code_tuple: tuple[str, ...] = ()
 
         for k in args:
-
             match k:
                 case Symbol():
                     res = self.gen_var(k, executor=self._executor)
@@ -149,7 +146,6 @@ class LowLeveQLang(BaseLowLevelQLang):
                     raise NotImplementedError()
 
                 case InstrIR():
-
                     match instr_res := self.gen_instrs(instr=k, **kwargs):
                         case Ok():
                             code_tuple += instr_res.result()
@@ -187,7 +183,6 @@ class LowLeveQLang(BaseLowLevelQLang):
         )
 
         for name, obj in inspect.getmembers(instr_module, inspect.isclass):
-
             if (x := getattr(obj, "name", False)) and x == instr.name:
                 res_instr, res_status = obj()(
                     idxs=self._idx.in_use_by[self._qdata],
@@ -222,11 +217,8 @@ class LowLeveQLang(BaseLowLevelQLang):
         code += "\n".join(self.init_qlang()) + "\n\n"
 
         for instr in self._code:  # type: ignore [attr-defined]
-
             if instr.args:
-
                 match gen_args := self.gen_args(instr.args):
-
                     case Ok():
                         if gen_args.result():
                             code += "\n".join(gen_args.result()) + "\n"
@@ -241,7 +233,6 @@ class LowLeveQLang(BaseLowLevelQLang):
             match gen_instr := self.gen_instrs(
                 instr=instr, idx=self._idx, executor=self._executor
             ):
-
                 case Ok():
                     code += "\n".join(gen_instr.result())
 

--- a/python/src/hhat_lang/low_level/target_backend/qiskit/openqasm/code_executor.py
+++ b/python/src/hhat_lang/low_level/target_backend/qiskit/openqasm/code_executor.py
@@ -68,7 +68,6 @@ def execute_program(
     res = sample_circuit(circ, qdata)
 
     match res:
-
         # in case it had an error
         case InvalidQuantumComputedResult():
             # TODO: define properly what to do next
@@ -76,7 +75,6 @@ def execute_program(
 
         # should contain the counts with bitstrings as keys (`Counter`?)
         case _:
-
             if debug:
                 print(res)
 

--- a/python/tests/dialects/heather/code/simple_ir/test_ir.py
+++ b/python/tests/dialects/heather/code/simple_ir/test_ir.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from hhat_lang.core.data.core import Symbol, CoreLiteral
+from hhat_lang.dialects.heather.code.simple_ir_builder.ir import (
+    IR,
+    IRBlock,
+    IRDeclare,
+    IRAssign,
+    IRArgs,
+    IRCall, IRFlag,
+)
+
+
+def test_dac1() -> None:
+    qq = Symbol("@q")
+    q1 = CoreLiteral("@1", lit_type="@int")
+    qu3 = Symbol("@u3")
+    qredim = Symbol("@redim")
+
+    i1 = IRDeclare(var=qq, var_type=qu3)
+    assert i1.instr == IRFlag.DECLARE
+    assert i1.args == (qq, qu3)
+
+    i2 = IRAssign(var=qq, value=q1)
+    assert i2.instr == IRFlag.ASSIGN
+    assert i2.args == (qq, q1)
+
+    i3 = IRCall(caller=qredim, args=IRArgs(qq))
+    i3_args_block_name = IRBlock(IRArgs(qq)).name
+    assert i3.instr == IRFlag.CALL
+    assert i3.args == (qredim, i3_args_block_name)
+
+    block1 = IRBlock(i1, i2, i3)
+    assert block1.instrs == (i1, i2, i3)
+
+    ir1 = IR()
+    ir1.add_new_block(block1)
+    assert block1.name in ir1.table
+    assert ir1.table[block1.name] == block1
+
+    print()
+    print(ir1)

--- a/python/tests/dialects/heather/interpreter/quantum/test_program.py
+++ b/python/tests/dialects/heather/interpreter/quantum/test_program.py
@@ -3,18 +3,25 @@ from __future__ import annotations
 from itertools import product
 
 import pytest
-from hhat_lang.core.code.ir import InstrIRFlag, TypeIR
+from hhat_lang.core.code.ir import TypeIR
 from hhat_lang.core.data.core import CoreLiteral, Symbol
-from hhat_lang.core.memory.core import MemoryManager
+from hhat_lang.core.memory.core import MemoryManager, SymbolTable
 from hhat_lang.dialects.heather.code.simple_ir_builder.ir import (
     FnIR,
     IRArgs,
     IRBlock,
-    IRInstr,
+    IRCall,
 )
 from hhat_lang.dialects.heather.interpreter.classical.executor import Evaluator
 from hhat_lang.dialects.heather.interpreter.quantum.program import Program
 from hhat_lang.low_level.quantum_lang.openqasm.v2.qlang import LowLeveQLang
+
+
+# FIXME: skipping whole file until LowLeveLQLang is fixed with the new IR
+pytest.skip(
+    "skipping whole file until LowLeveLQLang is fixed with the new IR",
+    allow_module_level=True
+)
 
 
 def test_simple_empty_redim_program(MAX_ATOL_STATES_GATE: float) -> None:
@@ -26,11 +33,10 @@ def test_simple_empty_redim_program(MAX_ATOL_STATES_GATE: float) -> None:
 
     ex = Evaluator(mem, TypeIR(), FnIR())
 
-    block = IRBlock()
-    block.add_instr(IRInstr(Symbol("@redim"), IRArgs(), InstrIRFlag.CALL))
+    block = IRBlock(IRCall(Symbol("@redim"), IRArgs()))
 
     program = Program(
-        qdata=qv, idx=mem.idx, block=block, qlang=LowLeveQLang, executor=ex
+        qdata=qv, idx=mem.idx, block=block, qlang=LowLeveQLang, executor=ex, symboltable=SymbolTable()
     )
 
     res = program.run(debug=False)
@@ -47,11 +53,12 @@ def test_simple_literal_redim_program(
 
     ex = Evaluator(mem, TypeIR(), FnIR())
 
-    block = IRBlock()
-    block.add_instr(IRInstr(Symbol("@redim"), IRArgs(ql), InstrIRFlag.CALL))
+    block = IRBlock(IRCall(caller=Symbol("@redim"), args=IRArgs(ql)))
+
+    table = SymbolTable()
 
     program = Program(
-        qdata=ql, idx=mem.idx, block=block, qlang=LowLeveQLang, executor=ex
+        qdata=ql, idx=mem.idx, block=block, qlang=LowLeveQLang, executor=ex, symboltable=table
     )
 
     res = program.run(debug=False)

--- a/python/tests/dialects/heather/interpreter/test_symboltable.py
+++ b/python/tests/dialects/heather/interpreter/test_symboltable.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from hhat_lang.core.memory.core import SymbolTable
+from hhat_lang.core.data.fn_def import BaseFnKey, BaseFnCheck
+from hhat_lang.core.data.core import WorkingData, Symbol, CompositeSymbol, CoreLiteral
+from hhat_lang.core.code.ir import InstrIRFlag
+from hhat_lang.dialects.heather.code.simple_ir_builder.ir import (
+    IRBlock,
+    IRCall,
+    IRArgs,
+)
+
+
+@pytest.mark.parametrize(
+    "fn_key, block, fn_check,",
+    [
+        (
+            # fn sum (a:u64 b:u64) u64 { add(a b) }
+            BaseFnKey(
+                fn_name=Symbol("sum"),
+                fn_type=Symbol("u64"),
+                args_names=(
+                    Symbol("a"),
+                    Symbol("b"),
+                ),
+                args_types=(
+                    Symbol("u64"),
+                    Symbol("u64"),
+                ),
+            ),
+            IRBlock(
+                IRCall(
+                    caller=Symbol("add"),
+                    args=IRArgs(Symbol("a"), Symbol("b")),
+                )
+            ),
+            BaseFnCheck(
+                fn_name=Symbol("sum"),
+                fn_type=Symbol("u64"),
+                args_types=(
+                    Symbol("u64"),
+                    Symbol("u64"),
+                ),
+            ),
+        ),
+    ],
+)
+def test_symboltable_fn(
+    fn_key: BaseFnKey, block: IRBlock, fn_check: BaseFnCheck
+) -> None:
+    st = SymbolTable()
+    st.add_fn(fn_key, block)
+
+    assert st.get_fn(fn_check)

--- a/python/tests/dialects/heather/parsing/ex_fn01.hat
+++ b/python/tests/dialects/heather/parsing/ex_fn01.hat
@@ -1,1 +1,1 @@
-fn sum (a:u64 b:u64) u64 { add(a b) }
+fn sum (a:u64 b:u64) u64 { ::add(a b) }

--- a/python/tests/dialects/heather/parsing/ex_fn02.hat
+++ b/python/tests/dialects/heather/parsing/ex_fn02.hat
@@ -1,1 +1,1 @@
-fn @sum (@a:@u3 @b:@u3) @u3 { @add(@a @b) }
+fn @sum (@a:@u3 @b:@u3) @u3 { ::@add(@a @b) }

--- a/python/tests/dialects/heather/parsing/ex_main03.hat
+++ b/python/tests/dialects/heather/parsing/ex_main03.hat
@@ -1,0 +1,3 @@
+use (type:geometry.euclidian.space)
+
+main {}

--- a/python/tests/dialects/heather/parsing/ex_main04.hat
+++ b/python/tests/dialects/heather/parsing/ex_main04.hat
@@ -1,0 +1,3 @@
+use (type:geometry.{euclidian.space differential.form})
+
+main {}

--- a/python/tests/dialects/heather/parsing/ex_main05.hat
+++ b/python/tests/dialects/heather/parsing/ex_main05.hat
@@ -1,0 +1,9 @@
+use (
+  type:[
+    geometry.{euclidian.space differential.form}
+    std.io.socket
+  ]
+  fn:math.{sin cos tan}
+)
+
+main {}

--- a/python/tests/dialects/heather/parsing/test_parse.py
+++ b/python/tests/dialects/heather/parsing/test_parse.py
@@ -4,11 +4,27 @@ from pathlib import Path
 
 import pytest
 from hhat_lang.dialects.heather.code.ast import (
+    ArgTypePair,
+    Body,
+    Call,
+    CallArgs,
+    CompositeId,
+    CompositeIdWithClosure,
     EnumTypeMember,
+    Expr,
+    FnArgs,
+    FnDef,
+    FnImport,
     Id,
+    Imports,
+    Literal,
+    Main,
+    OnlyValue,
     Program,
+    Return,
     SingleTypeMember,
     TypeDef,
+    TypeImport,
     TypeMember,
 )
 from hhat_lang.dialects.heather.parsing.run import (
@@ -17,9 +33,6 @@ from hhat_lang.dialects.heather.parsing.run import (
 )
 
 THIS = Path(__file__).parent
-
-# skipping this file until the parser
-# pytest.skip(allow_module_level=True)
 
 
 def test_parse_grammar() -> None:
@@ -70,15 +83,201 @@ def test_parse_type_sample_file(hat_file: str, res: Program) -> None:
     assert parsed == res
 
 
-@pytest.mark.skip()
-@pytest.mark.parametrize("hat_file", ["ex_fn01.hat", "ex_fn02.hat"])
-def test_parse_fn_sample_file(hat_file) -> None:
+@pytest.mark.parametrize(
+    "hat_file,res",
+    [
+        (
+            "ex_fn01.hat",
+            Program(
+                fns=(
+                    FnDef(
+                        fn_name=Id("sum"),
+                        fn_type=Id("u64"),
+                        args=FnArgs(
+                            ArgTypePair(arg_name=Id("a"), arg_type=Id("u64")),
+                            ArgTypePair(arg_name=Id("b"), arg_type=Id("u64")),
+                        ),
+                        body=Body(
+                            Return(
+                                Expr(
+                                    Call(
+                                        caller=Id("add"),
+                                        args=CallArgs(
+                                            OnlyValue(value=Id("a")),
+                                            OnlyValue(value=Id("b")),
+                                        ),
+                                    )
+                                )
+                            )
+                        ),
+                    ),
+                )
+            ),
+        ),
+        (
+            "ex_fn02.hat",
+            Program(
+                fns=(
+                    FnDef(
+                        fn_name=Id("@sum"),
+                        fn_type=Id("@u3"),
+                        args=FnArgs(
+                            ArgTypePair(arg_name=Id("@a"), arg_type=Id("@u3")),
+                            ArgTypePair(arg_name=Id("@b"), arg_type=Id("@u3")),
+                        ),
+                        body=Body(
+                            Return(
+                                Expr(
+                                    Call(
+                                        caller=Id("@add"),
+                                        args=CallArgs(
+                                            OnlyValue(value=Id("@a")),
+                                            OnlyValue(value=Id("@b")),
+                                        ),
+                                    )
+                                )
+                            )
+                        ),
+                    ),
+                )
+            ),
+        ),
+    ],
+)
+def test_parse_fn_sample_file(hat_file: str, res: Program) -> None:
     hat_file = (THIS / hat_file).resolve()
-    assert parse_file(hat_file)
+    parsed = parse_file(hat_file)
+    assert parsed == res
+
+
+@pytest.mark.parametrize(
+    "hat_file, res",
+    [
+        ("ex_main01.hat", Program(main=Main(Body()))),
+        (
+            "ex_main02.hat",
+            Program(
+                main=Main(
+                    Body(
+                        Expr(
+                            Call(
+                                caller=Id("print"),
+                                args=CallArgs(
+                                    Call(
+                                        caller=Id("add"),
+                                        args=CallArgs(
+                                            OnlyValue(
+                                                value=Literal(
+                                                    value="1", value_type="int"
+                                                )
+                                            ),
+                                            OnlyValue(
+                                                value=Literal(
+                                                    value="2", value_type="int"
+                                                )
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+        ),
+        (
+            "ex_main03.hat",
+            Program(
+                imports=Imports(
+                    type_import=(
+                        TypeImport(
+                            type_list=(
+                                CompositeId(
+                                    Id("geometry"), Id("euclidian"), Id("space")
+                                ),
+                            )
+                        ),
+                    ),
+                    fn_import=(),
+                ),
+                main=Main(),
+            ),
+        ),
+        (
+            "ex_main04.hat",
+            Program(
+                imports=Imports(
+                    type_import=(
+                        TypeImport(
+                            type_list=(
+                                CompositeIdWithClosure(
+                                    CompositeId(Id("euclidian"), Id("space")),
+                                    CompositeId(Id("differential"), Id("form")),
+                                    name=Id("geometry"),
+                                ),
+                            ),
+                        ),
+                    ),
+                    fn_import=(),
+                ),
+                main=Main(),
+            ),
+        ),
+        (
+            "ex_main05.hat",
+            Program(
+                imports=Imports(
+                    type_import=(
+                        TypeImport(
+                            type_list=(
+                                CompositeIdWithClosure(
+                                    CompositeId(Id("euclidian"), Id("space")),
+                                    CompositeId(Id("differential"), Id("form")),
+                                    name=Id("geometry"),
+                                ),
+                                CompositeId(Id("std"), Id("io"), Id("socket")),
+                            ),
+                        ),
+                    ),
+                    fn_import=(
+                        FnImport(
+                            fn_list=(
+                                CompositeIdWithClosure(
+                                    Id("sin"),
+                                    Id("cos"),
+                                    Id("tan"),
+                                    name=Id("math"),
+                                ),
+                            )
+                        ),
+                    ),
+                ),
+                main=Main(),
+            ),
+        ),
+    ],
+)
+def test_parse_main_sample_file(hat_file: str, res: Program) -> None:
+    # TODO: add the Program object for each of the files to test
+    hat_file = (THIS / hat_file).resolve()
+    parsed = parse_file(hat_file)
+    assert parsed == res
 
 
 @pytest.mark.skip()
-@pytest.mark.parametrize("hat_file", ["ex_main01.hat", "ex_main02.hat"])
-def test_parse_main_sample_file(hat_file) -> None:
-    hat_file = (THIS / hat_file).resolve()
-    assert parse_file(hat_file)
+def test_parse_main_types_files() -> None:
+    # TODO: write main and type files to test parsing throughout files
+    pass
+
+
+@pytest.mark.skip()
+def test_parse_main_fns_files() -> None:
+    # TODO: write main and fns files to test parsing throughout files
+    pass
+
+
+@pytest.mark.skip()
+def test_parse_full_examples() -> None:
+    # TODO: write code with main, types and fns files, with calling on
+    #   different ones, circular import, etc
+    pass

--- a/python/tests/lowlevel/qlang/openqasm/v2/test_lowlevelqlang.py
+++ b/python/tests/lowlevel/qlang/openqasm/v2/test_lowlevelqlang.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
-from hhat_lang.core.code.ir import InstrIRFlag, TypeIR
+import pytest
+from hhat_lang.core.code.ir import TypeIR
 from hhat_lang.core.data.core import CoreLiteral, Symbol
-from hhat_lang.core.memory.core import MemoryManager, Stack
+from hhat_lang.core.memory.core import MemoryManager, Stack, SymbolTable
 from hhat_lang.dialects.heather.code.simple_ir_builder.ir import (
     FnIR,
     IRArgs,
     IRBlock,
-    IRInstr,
+    IRCall,
 )
 from hhat_lang.dialects.heather.interpreter.classical.executor import Evaluator
 from hhat_lang.low_level.quantum_lang.openqasm.v2.qlang import LowLeveQLang
+
+
+# FIXME: skipping whole file until LowLevelQLang is fixed with the new IR
+pytest.skip(
+    "skipping whole file until LowLeveLQLang is fixed with the new IR",
+    allow_module_level=True
+)
 
 
 def test_gen_program_single_empty_redim() -> None:
@@ -31,10 +39,9 @@ measure q -> c;
 
     ex = Evaluator(mem, TypeIR(), FnIR())
 
-    block = IRBlock()
-    block.add_instr(IRInstr(Symbol("@redim"), IRArgs(), InstrIRFlag.CALL))
+    block = IRBlock(IRCall(Symbol("@redim"), IRArgs()))
 
-    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack(), SymbolTable())
     res = qlang.gen_program()
 
     assert res == code_snippet
@@ -60,16 +67,13 @@ measure q -> c;
 
     ex = Evaluator(mem, TypeIR(), FnIR())
 
-    block = IRBlock()
-    block.add_instr(
-        IRInstr(
-            name=Symbol("@redim"),
+    block = IRBlock(IRCall(
+            caller=Symbol("@redim"),
             args=IRArgs(CoreLiteral(Symbol("@5").value, "@u3")),
-            flag=InstrIRFlag.CALL,
         )
     )
 
-    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack(), SymbolTable())
     res = qlang.gen_program()
     print(res)
     assert res == code_snippet
@@ -93,10 +97,9 @@ measure q -> c;
 
     ex = Evaluator(mem, TypeIR(), FnIR())
 
-    block = IRBlock()
-    block.add_instr(IRInstr(Symbol("@not"), IRArgs(), InstrIRFlag.CALL))
+    block = IRBlock(IRCall(Symbol("@not"), IRArgs()))
 
-    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack(), SymbolTable())
     res = qlang.gen_program()
 
     assert res == code_snippet
@@ -121,10 +124,9 @@ measure q -> c;
 
     ex = Evaluator(mem, TypeIR(), FnIR())
 
-    block = IRBlock()
-    block.add_instr(IRInstr(Symbol("@not"), IRArgs(), InstrIRFlag.CALL))
+    block = IRBlock(IRCall(Symbol("@not"), IRArgs()))
 
-    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack(), SymbolTable())
     res = qlang.gen_program()
 
     assert res == code_snippet
@@ -150,10 +152,9 @@ measure q -> c;
 
     ex = Evaluator(mem, TypeIR(), FnIR())
 
-    block = IRBlock()
-    block.add_instr(IRInstr(Symbol("@not"), IRArgs(), InstrIRFlag.CALL))
+    block = IRBlock(IRCall(Symbol("@not"), IRArgs()))
 
-    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack(), SymbolTable())
     res = qlang.gen_program()
 
     assert res == code_snippet
@@ -180,10 +181,9 @@ measure q -> c;
 
     ex = Evaluator(mem, TypeIR(), FnIR())
 
-    block = IRBlock()
-    block.add_instr(IRInstr(Symbol("@not"), IRArgs(), InstrIRFlag.CALL))
+    block = IRBlock(IRCall(Symbol("@not"), IRArgs()))
 
-    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack())
+    qlang = LowLeveQLang(Symbol("@v"), block, mem.idx, ex, Stack(), SymbolTable())
     res = qlang.gen_program()
 
     assert res == code_snippet


### PR DESCRIPTION
Previous `IR` structure and logic were lacking essential working pieces for most of the non-trivial simple instructions. Now it should work to represent all the possible expressions, such as declare, assign, call, call with body, any combination of the previous ones and more.

work in progress.

@q-inho we discuss about this PR later. You can check the code at the [new IR file](https://github.com/hhat-lang/hhat_lang/blob/dev/python_impl/min_lang/python/src/hhat_lang/dialects/heather/code/simple_ir_builder/ir.py).

I also placed a [test](https://github.com/hhat-lang/hhat_lang/blob/dev/python_impl/min_lang/python/tests/dialects/heather/code/simple_ir/test_ir.py) so we can check how it looks like and have proper ideas, comments, suggestions, critiques, etc. The test is basically as follows:

https://github.com/hhat-lang/hhat_lang/blob/1a23ff9b4dfd8dfca946f307e1bcf0eb7cb89680/python/tests/dialects/heather/code/simple_ir/test_ir.py#L14-L42