### PR TITLE
Add README.md to python/ subfolders

### DIFF
--- a/python/src/hhat_lang/core/README.md
+++ b/python/src/hhat_lang/core/README.md
@@ -1,0 +1,117 @@
+# Core
+
+The H-hat core framework. Provides the abstract foundations, rule system, and shared infrastructure that all H-hat dialects build upon.
+
+## Overview
+
+H-hat is a hybrid classical-quantum programming language framework. The core module defines the contracts and primitives that any dialect must implement: how code is represented (AST, IR), how data is typed and stored (type system, variables, memory), how execution works (evaluators, quantum programs), and how errors are handled.
+
+The fundamental design principle is the **dual-paradigm model**: all data is either classical or quantum, identified by the `DataParadigm` enum. Quantum identifiers use the `@` prefix convention (e.g., `@x`, `@true`, `@u3`). The core enforces that quantum types can contain classical members, but classical types cannot contain quantum members.
+
+## Design Principles
+
+**Why two paradigms?** Quantum computation requires fundamentally different handling than classical computation -- qubits can't be freely copied (no-cloning theorem), measurement is destructive, and operations accumulate as instruction sequences rather than producing immediate values. By making the paradigm distinction first-class, H-hat lets the compiler and runtime route data through the correct execution path automatically.
+
+**The containment rule** (`check_quantum_type_correctness` in `code/utils.py`) exists because quantum data requires special resource management (qubit allocation, measurement). Classical containers have no mechanism for this, so allowing quantum members inside classical types would lose track of qubit lifecycle. The reverse -- classical data inside quantum types -- is safe because classical values are freely copyable.
+
+**Error propagation**: The codebase uses two complementary strategies. Functions that validate inputs (type checks, index bounds) return `ErrorHandler` instances instead of raising them. This lets callers inspect errors without stack unwinding. The `Result`/`Ok`/`Error` types in `utils.py` formalize this pattern for instruction execution. Exceptions are reserved for actual programming errors (missing implementations, violated invariants).
+
+## Directory Structure
+
+```
+core/
+  __init__.py         # DataParadigm enum (CLASSICAL / QUANTUM)
+  namespace.py        # Namespace and FullName for qualified identifiers
+  utils.py            # SymbolOrdered dict, Result/Ok/Error pattern
+  code/               # AST, IR, and instruction abstractions
+  data/               # Data primitives (Symbol, CoreLiteral) and variable containers
+  error_handlers/     # ErrorCodes enum and 20+ concrete error classes
+  execution/          # BaseEvaluator and BaseProgram ABCs
+  imports/            # TypeImporter for resolving type definitions
+  lowlevel/           # BaseLowLevelQLang ABC for quantum language backends
+  memory/             # IndexManager, Stack, Heap, MemoryManager
+  types/              # Type system (data structures, built-in types, size resolution)
+```
+
+## Top-Level Files
+
+### `__init__.py`
+
+**`DataParadigm`** -- `StrEnum` with two values: `CLASSICAL` and `QUANTUM`. This is the most fundamental type in H-hat -- it classifies every piece of data, every instruction, and every type as belonging to one of these two paradigms.
+
+### namespace.py
+
+**`Namespace`** -- Tuple-based hierarchical namespace (e.g., `("math", "linear")`). Supports containment checks.
+
+**`FullName`** -- Combines a `Namespace` with a single `name` string for fully-qualified identifiers (e.g., `math.linear.Vector`).
+
+### utils.py
+
+**`SymbolOrdered`** -- An `OrderedDict` wrapper that accepts `Symbol`, `CompositeSymbol`, `WorkingData`, `str`, or `int` as keys, automatically converting strings to `Symbol` objects. Used throughout the type system and variable containers for ordered member storage.
+
+**`Result`** / **`Ok`** / **`Error`** -- Monadic error pattern for instruction execution. `Ok` wraps a successful value; `Error` wraps an `ErrorHandler`. Callers inspect the result type instead of catching exceptions, enabling error propagation without stack unwinding.
+
+## Sub-Packages
+
+| Package | Purpose | Details |
+|---------|---------|---------|
+| [`code/`](code/) | AST nodes, IR building blocks, instruction base classes | [README](code/README.md) |
+| [`data/`](data/) | Symbol/Literal primitives, variable containers with ownership | [README](data/README.md) |
+| [`error_handlers/`](error_handlers/) | Structured error codes and error classes | [README](error_handlers/README.md) |
+| [`execution/`](execution/) | Abstract evaluator and quantum program bases | [README](execution/README.md) |
+| [`imports/`](imports/) | Type definition resolution from `.hat` files | [README](imports/README.md) |
+| [`lowlevel/`](lowlevel/) | Abstract interface for quantum language backends | [README](lowlevel/README.md) |
+| [`memory/`](memory/) | Runtime memory management (indexes, stack, heap) | [README](memory/README.md) |
+| [`types/`](types/) | Type data structures, built-in types, size resolution | [README](types/README.md) |
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph core["Core Framework"]
+        DP["DataParadigm\n(CLASSICAL / QUANTUM)"]
+
+        subgraph code_layer["Code Representation"]
+            AST["AST\n(Node, Terminal)"]
+            IR["IR\n(InstrIR, BlockIR, BodyIR)"]
+            Tables["TypeIR + BaseFnIR"]
+        end
+
+        subgraph data_layer["Data Layer"]
+            Data["WorkingData\n(Symbol, CoreLiteral)"]
+            Vars["BaseDataContainer\n(Const, Immutable, Mutable, Appendable)"]
+            Types["BaseTypeDataStructure\n(Single, Struct, Array, Enum, Union)"]
+        end
+
+        subgraph runtime["Runtime"]
+            Exec["BaseEvaluator"]
+            Prog["BaseProgram"]
+            Mem["MemoryManager\n(Stack, Heap, IndexManager)"]
+            LL["BaseLowLevelQLang"]
+        end
+
+        Errors["ErrorHandler\n(cross-cutting)"]
+        Imports["TypeImporter"]
+    end
+
+    AST --> IR
+    IR --> Tables
+    Tables --> Exec
+    Types --> Tables
+    Data --> Vars
+    Types -->|"instantiates"| Vars
+    Exec --> Mem
+    Prog --> LL
+    Prog --> Mem
+    Imports -->|"populates"| Tables
+```
+
+## Connections to Other Modules
+
+- **[`../dialects/heather/`](../dialects/heather/)**: The reference dialect. Implements concrete AST nodes, IR builders, parser, evaluator, and quantum program using core's abstract bases.
+- **[`../low_level/`](../low_level/)**: Implements `BaseLowLevelQLang` for specific quantum languages (OpenQASM v2) and target backends (Qiskit).
+- **[`../toolchain/`](../toolchain/)**: CLI and project management. Uses the dialect's parser to execute H-hat code.
+
+## Current Status
+
+The core framework's abstract contracts and shared infrastructure are solidly defined. Key implementations: `SymbolOrdered`, `MemoryManager` (with `IndexManager`, `Stack`, `Heap`), `TypeIR`, `BodyIR`, `ErrorHandler` hierarchy, `TypeImporter`, and all built-in types. Stubs remaining: `PIDManager`, `SymbolTable`, some size resolvers, and `borrow`/`transfer` semantics on variable containers.

--- a/python/src/hhat_lang/core/code/README.md
+++ b/python/src/hhat_lang/core/code/README.md
@@ -1,0 +1,92 @@
+# Code
+
+Abstract representations for AST nodes, intermediate representation (IR), and instruction base classes. Dialects implement concrete versions of these abstractions to define their syntax and compilation pipeline.
+
+## Overview
+
+This module provides the scaffolding that connects parsing to execution. The `AST` classes represent parsed source code as a tree, the instruction classes (`QInstr`, `CInstr`) define callable quantum and classical operations, and the IR classes (`InstrIR`, `BlockIR`, `BodyIR`, `TypeIR`, `BaseFnIR`, `BaseIR`) organize compiled code into a form the evaluator can execute.
+
+## Directory Structure
+
+```
+code/
+  __init__.py
+  ast.py            # AST abstract base classes (AST, Node, Terminal)
+  instructions.py   # Instruction ABCs (BaseInstr, QInstr, CInstr)
+  ir.py             # IR building blocks, type/function tables, BaseIR
+  utils.py          # InstrStatus enum, quantum type correctness check
+```
+
+## Module Details
+
+### ast.py
+
+**`AST`** (ABC) -- Base for all syntax tree nodes. Has `name` (str) and `value` (tuple of strings, child ASTs, or nested tuples). Supports iteration, hashing, and equality. Two concrete subclasses:
+
+- **`Node(AST)`** -- Non-terminal (interior) nodes. Repr shows `Name(child1 child2 ...)`.
+- **`Terminal(AST)`** -- Leaf nodes representing tokens. Repr shows the token value directly.
+
+Dialects extend these to define their specific syntax nodes (e.g., Heather defines `Id`, `Literal`, `FnDef`, `TypeDef`, `Program`, etc. in [`../../dialects/heather/code/ast.py`](../../dialects/heather/code/ast.py)).
+
+### instructions.py
+
+**`QInstrFlag`** -- Enum for special instruction behavior. `NONE` (default) and `SKIP_GEN_ARGS` (tells the low-level backend to skip standard argument generation). This flag exists because some instructions -- like `@nez` (not-equal-zero conditional) -- need to interpret their arguments in a custom way rather than having the backend generate code for each argument independently. When the backend's `gen_instrs()` encounters an instruction with `SKIP_GEN_ARGS`, it passes the raw arguments directly to the instruction class and lets it handle code generation internally.
+
+**`BaseInstr`** (ABC) -- Base instruction with `status` (InstrStatus), abstract `is_quantum`, `paradigm`, and `__call__()`. Two branches:
+
+- **`QInstr(BaseInstr)`** -- Quantum instruction base. `is_quantum` returns `True`, `paradigm` returns `DataParadigm.QUANTUM`. Has a `flag` attribute and `skip_gen_args` property.
+- **`CInstr(BaseInstr)`** -- Classical instruction base. `is_quantum` returns `False`, `paradigm` returns `DataParadigm.CLASSICAL`.
+
+Concrete instructions live in the low-level backends (e.g., `QRedim`, `QSync`, `QNot` in [`../../low_level/quantum_lang/openqasm/v2/instructions.py`](../../low_level/quantum_lang/openqasm/v2/instructions.py)).
+
+### ir.py
+
+Flag enums:
+- **`BlockIRFlag`** -- `INSTR_BLOCK`, `CONTROLFLOW_BLOCK`, `CLOSURE_BLOCK`, `CALL_BLOCK`
+- **`InstrIRFlag`** -- `ASSIGN`, `DECLARE`, `DECLARE_ASSIGN`, `CALL`, `CONTROLFLOW`, `TEST_COND`, `LOOP`, `LOOP_COND`, `RETURN`
+
+IR building blocks (ABCs):
+- **`InstrIR`** -- Single instruction: `name` (Symbol/CompositeSymbol), `args` (ArgsIR), `flag` (InstrIRFlag)
+- **`BlockIR`** -- Ordered collection of `InstrIR` and nested `BlockIR` items. Supports indexing and iteration.
+- **`ArgsIR`** -- Instruction arguments as a tuple. Supports containment and iteration.
+- **`BodyIR`** -- Mutable list of `InstrIR`/`BlockIR` items for function bodies and the main block. `push()` adds items, optionally applying a conversion function.
+
+Type annotations:
+- **`TypeTable`** -- `dict[Symbol | CompositeSymbol, BaseTypeDataStructure]` mapping type names to their definitions
+- **`FnTable`** -- `dict[tuple[name, type, args], BodyIR]` mapping function signatures to bodies
+
+IR table managers:
+- **`TypeIR`** -- Stores and retrieves type definitions. Prevents duplicate type names.
+- **`BaseFnIR`** (ABC) -- Abstract function table. Dialects implement how function lookup and call conventions work.
+- **`BaseIR`** (ABC) -- Top-level IR container combining `TypeIR`, `BaseFnIR`, and a main `BodyIR`. Provides `add_type()`, abstract `add_fn()`, and `add_body()`.
+
+### utils.py
+
+- **`InstrStatus`** -- IntEnum tracking instruction lifecycle: `NOT_STARTED` -> `RUNNING` -> `DONE` (or `TIMEOUT`, `INTERRUPTED`, `ERROR`)
+- **`check_quantum_type_correctness(names)`** -- Validates composite identifiers follow the rule: quantum data can contain classical members, but classical data cannot contain quantum members. Raises `ValueError` on violation.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Source["Source Code"] --> AST["AST (Node/Terminal)"]
+    AST --> IRBuilder["IR Builder (dialect)"]
+    IRBuilder --> TypeIR["TypeIR (type table)"]
+    IRBuilder --> FnIR["BaseFnIR (fn table)"]
+    IRBuilder --> BodyIR["BodyIR (main code)"]
+    TypeIR --> BaseIR
+    FnIR --> BaseIR
+    BodyIR --> BaseIR
+    BaseIR --> Evaluator["BaseEvaluator"]
+```
+
+## Connections
+
+- **[`../data/`](../data/)**: `InstrIR` uses `Symbol`/`CompositeSymbol` for instruction names; `TypeTable` maps them to type definitions
+- **[`../types/`](../types/)**: `TypeIR` stores `BaseTypeDataStructure` instances
+- **[`../execution/`](../execution/)**: `BaseEvaluator` receives `TypeIR` and `BaseFnIR` for execution
+- **Dialect implementations**: Heather's [`simple_ir_builder/ir.py`](../../dialects/heather/code/simple_ir_builder/ir.py) implements `IRInstr`, `IRBlock`, `IRArgs`, `FnIR`, `IR`
+
+## Current Status
+
+All abstract bases and IR container classes are fully defined. Concrete implementations live in the dialect layer.

--- a/python/src/hhat_lang/core/data/README.md
+++ b/python/src/hhat_lang/core/data/README.md
@@ -1,0 +1,104 @@
+# Data
+
+Fundamental data representation primitives for H-hat. Defines symbols, literals, composite data, and variable containers with ownership tracking.
+
+## Overview
+
+Every piece of data in H-hat -- variable names, function names, type names, literal values -- flows through the classes in this module. The `WorkingData` hierarchy represents atomic and composite data elements, while the `BaseDataContainer` hierarchy provides typed variable storage with mutability and quantum semantics.
+
+A central design principle: quantum identifiers and values use the `@` prefix (e.g., `@x`, `@true`, `@42`). The module enforces that quantum and classical data cannot be inconsistently mixed.
+
+## Directory Structure
+
+```
+data/
+  __init__.py
+  core.py          # WorkingData, Symbol, CoreLiteral, and composite data classes
+  variable.py      # Variable containers (constant, immutable, mutable, appendable)
+  utils.py         # VariableKind enum and quantum utility functions
+```
+
+## Module Details
+
+### core.py
+
+Defines two parallel class hierarchies for single-valued and multi-valued data:
+
+**`WorkingData`** -- Base for anything representable as a single string value with a type. Properties: `value`, `type`, `is_quantum`. Supports comparison operators via `_op_bitwise`.
+
+- **`Symbol(WorkingData)`** -- Names for variables, functions, types, or parameters. Quantum symbols have `@`-prefixed values. Type display is suppressed in repr.
+- **`Atomic(Symbol)`** -- Marker subclass for atomic data.
+- **`CoreLiteral(WorkingData)`** -- Typed literal values (e.g., `"42"` of type `"int"`). Validates quantum/classical consistency between value and type at construction. Provides a `bin` property with the binary representation.
+
+**`CompositeWorkingData`** -- Base for grouped data (tuples of strings). Has a `group_type` (`CompositeGroup.SymbolAttrs` or `CompositeGroup.Array`).
+
+- **`CompositeSymbol(CompositeWorkingData)`** -- Dotted identifiers like `module.function` or `namespace.type`.
+- **`CompositeLiteral(CompositeWorkingData)`** -- Arrays of literals.
+- **`CompositeMixData(CompositeWorkingData)`** -- Mixed arrays containing both literals and variables.
+
+`ACCEPTABLE_VALUES` maps type names to accepted Python types for validation (e.g., `"int" -> (int,)`, `"str" -> (str,)`).
+
+```mermaid
+classDiagram
+    WorkingData <|-- Symbol
+    WorkingData <|-- CoreLiteral
+    Symbol <|-- Atomic
+    CompositeWorkingData <|-- CompositeSymbol
+    CompositeWorkingData <|-- CompositeLiteral
+    CompositeWorkingData <|-- CompositeMixData
+
+    class WorkingData {
+        +value: str
+        +type: str
+        +is_quantum: bool
+    }
+    class Symbol {
+        "@" prefix = quantum
+    }
+    class CoreLiteral {
+        +bin: str
+    }
+    class CompositeWorkingData {
+        +value: tuple[str, ...]
+        +group_type: CompositeGroup
+    }
+```
+
+### variable.py
+
+**`BaseDataContainer`** (ABC) -- Abstract variable/constant container. Stores data in a `SymbolOrdered` dict. Tracks ownership state via `_borrowed` and `_transferred` flags. Provides `assign()`, `get()`, `borrow()`, `transfer()`, and `free()` methods. An `_instr_counter` tracks instruction ordering for quantum variables.
+
+**`VariableTemplate`** -- Factory (implemented via `__new__`) that creates the appropriate container based on `VariableKind` and quantum status:
+- Quantum variables always become `AppendableVariable` (they accumulate instructions)
+- Classical variables dispatch on the `VariableKind` flag
+- Mismatched quantum/classical name+type returns `VariableCreationError`
+
+Four concrete container types:
+
+| Class | Mutable | Quantum | Reassign |
+|-------|---------|---------|----------|
+| `ConstantData` | No | No | Never |
+| `ImmutableVariable` | No | No | Once only |
+| `MutableVariable` | Yes | No | Any time |
+| `AppendableVariable` | Yes | Yes/No | Accumulates |
+
+**Why quantum variables are always appendable**: Quantum operations don't produce immediate values -- they build up instruction sequences that are later compiled into a quantum circuit. Each `@redim`, `@sync`, or `@not` call appends to the variable's instruction list rather than replacing its content. This is why `VariableTemplate` always creates `AppendableVariable` for quantum data, regardless of the `VariableKind` requested.
+
+**Ownership semantics**: `BaseDataContainer` tracks `_borrowed` and `_transferred` flags, inspired by Rust-style ownership. A variable that has been transferred cannot be read (its data moved to another scope). A variable that is borrowed elsewhere cannot be freed. These checks are defined in `free()` (raises `VariableFreeingBorrowedError` if borrowed) and `get()`. Note: `borrow()` and `transfer()` are not yet implemented on concrete types -- they raise `NotImplementedError`.
+
+### utils.py
+
+- **`VariableKind`** -- Enum: `CONSTANT`, `IMMUTABLE`, `MUTABLE`, `APPENDABLE`
+- **`isquantum(data)`** -- Checks if data is quantum (string starts with `@` or has `is_quantum` attribute)
+- **`has_same_paradigm(data1, data2)`** -- Returns `True` if both are quantum or both are classical
+
+## Connections
+
+- **Used by [`../types/`](../types/)**: Type data structures use `VariableTemplate` to instantiate variables from type definitions
+- **Used by [`../memory/`](../memory/)**: `Heap` stores `BaseDataContainer` instances keyed by `Symbol`
+- **Used by [`../code/ir.py`](../code/ir.py)**: `TypeTable` maps `Symbol`/`CompositeSymbol` to type definitions
+- **Used by dialects**: IR builders convert dialect-specific AST nodes into `Symbol`, `CompositeSymbol`, and `CoreLiteral`
+
+## Current Status
+
+Core data classes and variable containers are implemented. `borrow()` and `transfer()` raise `NotImplementedError` in all concrete container types. `ConstantData.assign()` also raises `NotImplementedError`.

--- a/python/src/hhat_lang/core/error_handlers/README.md
+++ b/python/src/hhat_lang/core/error_handlers/README.md
@@ -1,0 +1,54 @@
+# Error Handlers
+
+Centralized error handling for the H-hat core. Defines error codes and concrete error classes used across the entire framework and its dialects.
+
+## Overview
+
+H-hat uses a dual error strategy: an `ErrorHandler` base exception class for structured errors, and the `Result`/`Ok`/`Error` pattern (in [`../utils.py`](../utils.py)) for monadic error propagation in instruction execution. When a function returns `ErrorHandler` instead of raising it, callers can inspect errors without unwinding the stack.
+
+## Directory Structure
+
+```
+error_handlers/
+  __init__.py
+  errors.py        # ErrorCodes enum, ErrorHandler ABC, and all concrete error classes
+```
+
+## Module Details
+
+### errors.py
+
+**`ErrorCodes`** -- Enum with 20+ error codes grouped by domain:
+
+| Domain | Codes | Triggered by |
+|--------|-------|-------------|
+| Index | `INDEX_ALLOC_ERROR`, `INDEX_VAR_HAS_INDEXES_ERROR`, `INDEX_INVALID_VAR_ERROR`, `INDEX_UNKNOWN_ERROR` | Qubit/index allocation in `IndexManager` |
+| Type | `TYPE_QUANTUM_ON_CLASSICAL_ERROR`, `TYPE_AND_MEMBER_NO_MATCH`, `TYPE_ADD_MEMBER_ERROR`, `TYPE_SINGLE_ASSIGN_ERROR`, `TYPE_STRUCT_ASSIGN_ERROR`, `TYPE_UNION_ASSIGN_ERROR`, `TYPE_ENUM_ASSIGN_ERROR` | Type system validation in [`../types/`](../types/) |
+| Container/Variable | `CONTAINER_VAR_ASSIGN_ERROR`, `CONTAINER_VAR_IS_IMMUTABLE_ERROR`, `VARIABLE_WRONG_MEMBER_ERROR`, `VARIABLE_CREATION_ERROR`, `VARIABLE_FREEING_BORROWED_ERROR` | Variable operations in [`../data/variable.py`](../data/variable.py) |
+| Cast | `CAST_NEG_TO_UNSIGNED_ERROR`, `CAST_INT_OVERFLOW_ERROR`, `CAST_ERROR` | Type casting in [`../types/builtin_base.py`](../types/builtin_base.py) |
+| Memory | `STACK_EMPTY_ERROR`, `STACK_OVERFLOW_ERROR`, `HEAP_INVALID_KEY_ERROR`, `HEAP_EMPTY_ERROR` | Stack/Heap operations in [`../memory/`](../memory/) |
+| Quantum | `INVALID_QUANTUM_COMPUTED_RESULT` | Target backend execution |
+| Instruction | `INSTR_NOTFOUND_ERROR`, `INSTR_STATUS_ERROR` | Instruction dispatch in low-level backends |
+
+**`ErrorHandler`** -- Abstract base class extending `BaseException`. Each subclass stores contextual data (variable names, values, limits) and implements `__call__()` to produce a human-readable error message. The `error_code` property returns the associated `ErrorCodes` member.
+
+**Concrete error classes** (20+): `IndexAllocationError`, `TypeQuantumOnClassicalError`, `ContainerVarError`, `CastNegToUnsignedError`, `StackEmptyError`, `HeapInvalidKeyError`, `InvalidQuantumComputedResult`, `InstrNotFoundError`, among others. Each corresponds to exactly one `ErrorCodes` value.
+
+## Connections
+
+This module is imported throughout the codebase:
+
+- **`core/data/variable.py`** returns `ContainerVarError`, `ContainerVarIsImmutableError`, `VariableCreationError`, `VariableFreeingBorrowedError`, `VariableWrongMemberError`
+- **`core/memory/core.py`** returns index and memory errors
+- **`core/types/`** returns type validation errors
+- **`low_level/`** returns `InstrNotFoundError`, `InvalidQuantumComputedResult`
+
+## Design Notes
+
+**Return vs. raise**: Throughout the codebase, most functions that can fail return an `ErrorHandler` instance rather than raising it. For example, `IndexManager.add()` returns `IndexVarHasIndexesError` if the variable is already registered, and `VariableTemplate.__new__()` returns `VariableCreationError` on paradigm mismatch. This pattern lets callers inspect errors as values (often using the `Result`/`Ok`/`Error` types from `utils.py`) without try/except overhead. Exceptions are reserved for true programming errors (assertions, `NotImplementedError` for stubs).
+
+**Adding new errors**: Each error needs three things: (1) a new `ErrorCodes` member, (2) a new class inheriting from `ErrorHandler` with `error_code` pointing to that member, and (3) a `__call__` method returning the human-readable message string.
+
+## Current Status
+
+Fully implemented. All error codes have corresponding concrete classes with context-aware messages.

--- a/python/src/hhat_lang/core/execution/README.md
+++ b/python/src/hhat_lang/core/execution/README.md
@@ -1,0 +1,58 @@
+# Execution
+
+Abstract base classes defining the evaluation and program execution contracts that H-hat dialects must implement.
+
+## Overview
+
+H-hat separates execution into two roles: the **evaluator** handles classical instruction execution with access to memory, type, and function tables; the **program** orchestrates quantum execution by coordinating a low-level quantum language, index allocation, and a quantum stack. Dialects provide concrete implementations of both.
+
+## Directory Structure
+
+```
+execution/
+  __init__.py
+  abstract_base.py      # BaseEvaluator ABC
+  abstract_program.py   # BaseProgram ABC
+```
+
+## Module Details
+
+### abstract_base.py
+
+**`BaseEvaluator`** (ABC) -- The main execution engine for a dialect. Holds:
+
+- `mem` -- `MemoryManager` for stack/heap/index operations
+- `type_table` -- `TypeIR` with all registered types
+- `fn_table` -- `BaseFnIR` with all registered functions
+
+Abstract methods: `run(code)` and `__call__()`. Dialects implement these to walk IR blocks and execute instructions against the memory manager.
+
+### abstract_program.py
+
+**`BaseProgram`** (ABC) -- Represents a quantum program unit. Holds:
+
+- `_qdata` -- `WorkingData` for the quantum data being processed
+- `_idx` -- `IndexManager` for qubit allocation
+- `_block` -- `BlockIR` containing the quantum instructions
+- `_executor` -- `BaseEvaluator` for fallback classical execution
+- `_qlang` -- `BaseLowLevelQLang` instance for low-level code generation
+- `_qstack` -- `BaseStack` for the quantum execution stack
+
+Abstract method: `run()` returns results or `ErrorHandler`.
+
+## Connections
+
+- **[`../memory/`](../memory/)**: `BaseEvaluator` owns a `MemoryManager`; `BaseProgram` uses `IndexManager` and `BaseStack`
+- **[`../code/ir.py`](../code/ir.py)**: Both use `TypeIR`, `BaseFnIR`, and `BlockIR`
+- **[`../lowlevel/`](../lowlevel/)**: `BaseProgram` delegates code generation to `BaseLowLevelQLang`
+- **Implementations**: Heather implements `BaseEvaluator` in [`../../dialects/heather/interpreter/classical/executor.py`](../../dialects/heather/interpreter/classical/executor.py) and `BaseProgram` in [`../../dialects/heather/interpreter/quantum/program.py`](../../dialects/heather/interpreter/quantum/program.py)
+
+## Design Notes
+
+**Why two execution roles?** Classical and quantum execution have fundamentally different models. Classical execution is imperative: walk the IR, evaluate each instruction immediately against memory. Quantum execution is deferred: accumulate instructions into a circuit, compile to a low-level language, run on a backend, then retrieve results. Separating these concerns lets each branch manage its own resource lifecycle (e.g., `BaseProgram` owns qubit allocation via `IndexManager`, while `BaseEvaluator` owns the general-purpose `MemoryManager`).
+
+**Classical fallback**: The quantum program holds a reference to `BaseEvaluator` because not all instructions in a quantum block may be supported by the low-level quantum language. For example, classical control flow or variable lookup within a quantum context falls back to the evaluator. This is noted as a TODO in the OpenQASM v2 backend.
+
+## Current Status
+
+Both ABCs are fully defined. Concrete implementations live in the dialect layer.

--- a/python/src/hhat_lang/core/imports/README.md
+++ b/python/src/hhat_lang/core/imports/README.md
@@ -1,0 +1,44 @@
+# Imports
+
+Handles loading and resolving type definitions from `.hat` source files within a project's `src/hat_types/` directory.
+
+## Overview
+
+When H-hat code uses `use(type: ...)` statements, the imported type names need to be resolved to their definitions. `TypeImporter` locates the corresponding `.hat` files, parses them for `type` declarations and nested `use(type: ...)` imports, and recursively resolves all transitive dependencies.
+
+## Directory Structure
+
+```
+imports/
+  __init__.py           # Exports TypeImporter
+  types_importer.py     # TypeImporter class with recursive resolution and caching
+```
+
+## Module Details
+
+### types_importer.py
+
+**`TypeImporter`** -- Main class for import resolution. Initialized with the project's `hat_types/` directory path.
+
+Key methods:
+
+- **`import_types(names)`** -- Entry point. Takes a list of `CompositeSymbol` names (e.g., `CompositeSymbol(("math", "vector"))`) and resolves them to their type definitions. Returns the parsed results.
+
+Internal helpers:
+
+- **`_parse_file(filepath)`** -- Parses a single `.hat` file to extract type names and import statements. Results are cached using `_PARSE_CACHE` with file modification time (mtime) invalidation, so unchanged files are not re-parsed.
+- **`_expand_group_closures(imports)`** -- Expands grouped import syntax (e.g., `A.{B, C}`) into individual import paths (`A.B`, `A.C`).
+- **`_parse_type_names(content)`** -- Extracts type declaration names from parsed content.
+- **`_parse_type_imports(content)`** -- Extracts `use(type: ...)` import references from parsed content.
+
+The resolution process walks the dependency graph, tolerating circular imports by tracking already-visited files in a `_processing` set. This is important because type definition files can reference each other (e.g., `types_a.hat` imports from `types_b.hat` which imports from `types_a.hat`) -- the importer simply skips files it's already processing rather than entering an infinite loop.
+
+## Connections
+
+- **[`../../dialects/heather/parsing/imports.py`](../../dialects/heather/parsing/imports.py)**: Calls `TypeImporter.import_types()` during the import resolution phase
+- **[`../../dialects/heather/parsing/run.py`](../../dialects/heather/parsing/run.py)**: `TypeImporter` uses the dialect's parser to parse `.hat` files
+- **[`../data/core.py`](../data/core.py)**: Works with `CompositeSymbol` for multi-part type names
+
+## Current Status
+
+Fully implemented, including mtime-based caching and recursive dependency resolution with circular import tolerance.

--- a/python/src/hhat_lang/core/lowlevel/README.md
+++ b/python/src/hhat_lang/core/lowlevel/README.md
@@ -1,0 +1,63 @@
+# Low-Level Language Abstraction
+
+Defines the abstract interface for transforming H-hat quantum data and IR instructions into low-level quantum language code (e.g., OpenQASM).
+
+## Overview
+
+When a H-hat program contains quantum instructions, the dialect's quantum program hands them to a low-level quantum language backend. This module defines the `BaseLowLevelQLang` contract that all such backends must implement.
+
+## Directory Structure
+
+```
+lowlevel/
+  __init__.py
+  abstract_qlang.py    # BaseLowLevelQLang ABC
+```
+
+## Module Details
+
+### abstract_qlang.py
+
+**`BaseLowLevelQLang`** (ABC) -- Holds quantum data and transforms it into target-specific code. Constructed with:
+
+- `qvar` (`WorkingData`) -- The quantum variable being processed
+- `code` (`IRBlock`) -- The IR block containing quantum instructions
+- `idx` (`IndexManager`) -- Qubit index allocator (used to determine `_num_idxs`)
+- `executor` (`BaseEvaluator`) -- Classical evaluator for fallback execution
+- `qstack` (`BaseStack`) -- Quantum-specific stack
+
+Abstract methods that backends must implement:
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `init_qlang()` | `tuple[str, ...]` | Generate language header (version, register declarations) |
+| `gen_instrs()` | `Result` or `ErrorHandler` | Translate a single IR instruction |
+| `gen_program()` | `str` | Produce the complete target-language program |
+| `__call__()` | `Any` | Callable interface |
+
+The constructor computes `_num_idxs` from the `IndexManager`'s allocation for the given quantum variable.
+
+> **Note**: The constructor currently imports `IRBlock` from `dialects/heather/code/simple_ir_builder/ir.py`. This is a known coupling between the core abstraction and the Heather dialect that may be refactored to use the abstract `BlockIR` from `core/code/ir.py` instead.
+
+## Connections
+
+- **Implemented by**: [`../../low_level/quantum_lang/openqasm/v2/qlang.py`](../../low_level/quantum_lang/openqasm/v2/qlang.py) (`LowLeveQLang`)
+- **Used by**: [`../execution/abstract_program.py`](../execution/abstract_program.py) (`BaseProgram`) and the Heather quantum program
+- **Depends on**: [`../memory/core.py`](../memory/core.py) (`IndexManager`, `BaseStack`), [`../execution/abstract_base.py`](../execution/abstract_base.py) (`BaseEvaluator`)
+
+## Implementing a New Backend
+
+To add a new low-level quantum language backend (e.g., NetQASM, Cirq):
+
+1. Create a class inheriting from `BaseLowLevelQLang`
+2. Implement `init_qlang()` to return the program header (version declarations, register definitions)
+3. Implement `gen_instrs()` to translate individual IR instructions to your target language
+4. Implement `gen_program()` to assemble the full program string from header, body, and measurements
+5. Create instruction classes inheriting from `QInstr`/`CInstr` (in `core/code/instructions.py`) with a `name` attribute matching the H-hat instruction name (e.g., `"@redim"`)
+6. Create a target backend executor with `load`, `sample`, and `execute` functions (see `low_level/target_backend/qiskit/` for reference)
+
+Currently, backend selection is hardcoded in the quantum program. A future configuration system will let projects specify their backend via config files.
+
+## Current Status
+
+ABC is fully defined. The only concrete implementation is the OpenQASM v2 backend.

--- a/python/src/hhat_lang/core/memory/README.md
+++ b/python/src/hhat_lang/core/memory/README.md
@@ -1,0 +1,66 @@
+# Memory
+
+Runtime memory management for H-hat programs. Handles qubit index allocation, stack operations, heap variable storage, and coordinates these through a unified memory manager.
+
+## Overview
+
+H-hat programs need to manage both classical data (stored on heap) and quantum resources (tracked by index allocation). The `MemoryManager` facade combines all memory subsystems into a single object that evaluators receive at construction time.
+
+## Directory Structure
+
+```
+memory/
+  __init__.py
+  core.py       # IndexManager, Stack, Heap, MemoryManager, and supporting classes
+```
+
+## Module Details
+
+### core.py
+
+**`IndexManager`** -- Manages qubit index allocation. Maintains a pool of available indexes (deque) and tracks which variables hold which indexes. Key lifecycle:
+
+1. `add(var_name, num_idxs)` -- Register a variable's qubit requirement
+2. `request(var_name)` -- Allocate indexes from the pool for the registered variable
+3. `free(var_name)` -- Release indexes back to the pool
+
+Properties: `max_number` (capacity), `available` (unallocated indexes), `allocated` (in-use indexes), `resources` (registered variable -> count), `in_use_by` (variable -> allocated index deque).
+
+Returns specific errors on failure: `IndexAllocationError` (not enough indexes), `IndexVarHasIndexesError` (variable already registered), `IndexInvalidVarError` (variable not found).
+
+**`BaseStack`** / **`Stack`** -- LIFO queue (wraps `LifoQueue`). Methods: `push()`, `pop()`, `peek()`. Used by evaluators during instruction execution and by the quantum branch as a quantum stack. Note: `peek()` is documented as an "expensive method" -- it pops the item and pushes it back (get-then-put pattern), so avoid calling it in tight loops.
+
+**`BaseHeap`** / **`Heap`** -- Dictionary-based storage mapping `Symbol` keys to `BaseDataContainer` values. Methods: `set()`, `get()`. Validates that keys are `Symbol` and values are `BaseDataContainer`, returning `HeapInvalidKeyError` on type mismatch.
+
+**`SymbolTable`** -- Intended for storing types and functions. Currently a stub.
+
+**`PIDManager`** -- Process ID management. Currently a stub (methods raise `NotImplementedError`).
+
+**`MemoryManager`** -- Facade combining all memory subsystems. Constructed with `max_num_index` to set qubit capacity. Properties: `stack`, `heap`, `symboltable`, `idx` (IndexManager).
+
+**`MemoryDataTypes`** -- Type alias for values that can be stored in memory: `BaseDataContainer | CoreLiteral | CompositeLiteral | Symbol | CompositeMixData`.
+
+```mermaid
+flowchart TB
+    MM["MemoryManager"]
+    MM --> Stack
+    MM --> Heap
+    MM --> IM["IndexManager"]
+    MM --> ST["SymbolTable (stub)"]
+    MM --> PID["PIDManager (stub)"]
+
+    IM -->|"allocates"| Qubits["Qubit Indexes (deque)"]
+    Heap -->|"stores"| Vars["BaseDataContainer instances"]
+    Stack -->|"manages"| Frames["MemoryDataTypes (LIFO)"]
+```
+
+## Connections
+
+- **[`../execution/`](../execution/)**: `BaseEvaluator` holds a `MemoryManager` instance
+- **[`../data/`](../data/)**: `Heap` stores `BaseDataContainer` instances; `IndexManager` tracks `WorkingData` variable registrations
+- **[`../lowlevel/`](../lowlevel/)**: `BaseLowLevelQLang` uses `IndexManager` and `BaseStack` for quantum resource tracking
+- **Dialect executors**: Both the classical evaluator and quantum program in Heather operate on the memory manager
+
+## Current Status
+
+`IndexManager`, `Stack`, `Heap`, and `MemoryManager` are fully implemented. `PIDManager` and `SymbolTable` are stubs. `Heap` does not yet support scope-based storage -- there are TODOs in `BaseHeap` and `Heap` to add scope-aware variable lifetime management, which will be needed for function calls and closures.

--- a/python/src/hhat_lang/core/types/README.md
+++ b/python/src/hhat_lang/core/types/README.md
@@ -1,0 +1,117 @@
+# Types
+
+The H-hat type system. Defines abstract type data structures, built-in classical and quantum types, and size resolution utilities.
+
+## Overview
+
+H-hat types define how data is structured, how variables are instantiated from type definitions, and how many qubits a quantum type requires. The type system enforces the core rule: quantum types can contain classical members, but classical types cannot contain quantum members.
+
+Types are registered in a `TypeIR` table (from [`../code/ir.py`](../code/ir.py)) and are used to create variable containers via `VariableTemplate` (from [`../data/variable.py`](../data/variable.py)).
+
+## Directory Structure
+
+```
+types/
+  __init__.py          # POINTER_SIZE = 32 constant
+  abstract_base.py     # BaseTypeDataStructure, Size, QSize
+  core.py              # SingleDS, ArrayDS, StructDS, UnionDS, EnumDS
+  builtin_base.py      # BuiltinSingleDS, cast functions, symbol constants
+  builtin_types.py     # Built-in type instances (Int, Bool, U32, QBool, QU3, etc.)
+  resolve_sizes.py     # Size resolution utilities
+```
+
+## Module Details
+
+### abstract_base.py
+
+**`Size`** -- Wrapper for classical bit-size information (e.g., `Size(32)` for a 32-bit type).
+
+**`QSize`** -- Quantum size as qubit count. Has `min` (minimum qubits) and optional `max` (maximum qubits, computed recursively for composite types by `_qsize_resolver()`). The min/max range exists because composite quantum types may have variable qubit requirements depending on member initialization -- `min` is the base requirement, `max` sums all possible member contributions. Does not account for ancilla qubits that low-level backends may add.
+
+**`BaseTypeDataStructure`** (ABC) -- Base for all type definitions. Properties: `name`, `is_quantum`, `is_builtin`, `size`, `qsize`, `is_array`, `members`. Uses a `SymbolOrdered` type container to store member definitions.
+
+Key abstract methods:
+- `add_member()` -- Register a member type (and optionally a name for struct members)
+- `__call__()` -- Instantiate a variable of this type using `VariableTemplate`
+
+### core.py
+
+Five concrete data structures:
+
+| Class | Description | Members | Status |
+|-------|-------------|---------|--------|
+| `SingleDS` | Single-member type (e.g., a newtype wrapper) | One member type | Implemented |
+| `StructDS` | Struct with named members | Multiple name-type pairs | Implemented |
+| `ArrayDS` | Array type (e.g., `[u64]`) | Element type | Stub |
+| `UnionDS` | Union type | Multiple member types | Stub |
+| `EnumDS` | Enum with variants | Variant definitions | Stub |
+
+`is_valid_member()` validates that classical types don't contain quantum members.
+
+`SingleDS.__call__()` and `StructDS.__call__()` create variable instances: they build a `SymbolOrdered` layout, pass it to `VariableTemplate`, and assign initial values.
+
+### builtin_base.py
+
+**`BuiltinSingleDS`** -- Built-in primitive type. Stores its name directly in `_type_container[0]`. Has `bitsize` property and `cast_from()` method for type casting.
+
+**Symbol constants** for type names:
+- Classical: `S_INT`, `S_BOOL`, `S_U16`, `S_U32`, `S_U64`
+- Quantum: `S_QINT`, `S_QBOOL`, `S_QU2`, `S_QU3`, `S_QU4`
+
+**`int_to_uN()`** -- Cast function for integer-to-unsigned conversion. Validates against negative values and overflow for the target bit width. Returns `CastNegToUnsignedError` or `CastIntOverflowError` on failure.
+
+### builtin_types.py
+
+Instantiates all built-in types. The `POINTER_SIZE` constant (currently 32 bits, defined in `__init__.py`) is used for the classical `Size` of all quantum types. This is because a quantum variable's classical representation is just a pointer/reference to its qubit indexes -- the actual data lives in the qubits themselves, not in classical memory.
+
+| Instance | Symbol | Size | QSize |
+|----------|--------|------|-------|
+| `Int` | `int` | None | -- |
+| `Bool` | `bool` | 8 bits | -- |
+| `U16` | `u16` | 16 bits | -- |
+| `U32` | `u32` | 32 bits | -- |
+| `U64` | `u64` | 64 bits | -- |
+| `QBool` | `@bool` | POINTER_SIZE | 1 qubit |
+| `QU2` | `@u2` | POINTER_SIZE | 2 qubits |
+| `QU3` | `@u3` | POINTER_SIZE | 3 qubits |
+| `QU4` | `@u4` | POINTER_SIZE | 4 qubits |
+
+Quantum types use `POINTER_SIZE` (32 bits) for their classical bit representation, since the actual data lives in qubits.
+
+### resolve_sizes.py
+
+**`_qsize_resolver()`** -- Recursively computes the maximum quantum size for composite types by summing member qsizes through the `TypeTable`. Used at compile time to determine total qubit requirements.
+
+Stub functions for future implementation: `ct_size()`, `ct_qsize()`, `runtime_size()`, `runtime_qsize()`.
+
+## Architecture
+
+```mermaid
+classDiagram
+    BaseTypeDataStructure <|-- SingleDS
+    BaseTypeDataStructure <|-- ArrayDS
+    BaseTypeDataStructure <|-- StructDS
+    BaseTypeDataStructure <|-- UnionDS
+    BaseTypeDataStructure <|-- EnumDS
+    BaseTypeDataStructure <|-- BuiltinSingleDS
+
+    class BaseTypeDataStructure {
+        +name: Symbol
+        +is_quantum: bool
+        +size: Size
+        +qsize: QSize
+        +add_member()
+        +__call__() → BaseDataContainer
+    }
+```
+
+## Connections
+
+- **[`../data/variable.py`](../data/variable.py)**: `__call__()` on type data structures creates variables via `VariableTemplate`
+- **[`../code/ir.py`](../code/ir.py)**: `TypeIR` stores type definitions as `dict[Symbol, BaseTypeDataStructure]`
+- **[`../error_handlers/`](../error_handlers/)**: Type validation returns `TypeQuantumOnClassicalError`, `TypeAndMemberNoMatchError`, `TypeSingleError`, `TypeStructError`
+- **[`../imports/`](../imports/)**: `TypeImporter` resolves type names that get registered here
+
+## Current Status
+
+`SingleDS`, `StructDS`, and `BuiltinSingleDS` are implemented with full member validation and variable instantiation. `ArrayDS`, `UnionDS`, and `EnumDS` raise `NotImplementedError`. Size resolution is partially implemented (`_qsize_resolver` works; compile-time and runtime resolvers are stubs).

--- a/python/src/hhat_lang/dialects/heather/README.md
+++ b/python/src/hhat_lang/dialects/heather/README.md
@@ -23,3 +23,66 @@ To evaluate a H-hat code inside a `.hat` file, use: [*in progress*]
 > [!NOTE]
 >
 > In progress.
+
+## Directory Structure
+
+```
+heather/
+  __init__.py
+  README.md
+  code/                    # AST definitions and IR builders
+    ast.py                 # 38 Heather-specific AST node classes
+    ir_builder.py          # AST -> IR conversion orchestrator
+    simple_ir_builder/     # Direct IR for the interpreter
+    ssa_ir_builder/        # SSA form IR for optimization (future)
+    mlir_builder/          # MLIR target (stub)
+  grammar/                 # Syntax definition
+    grammar.peg            # PEG grammar processed by Arpeggio
+  parsing/                 # Source code parsing
+    run.py                 # parse() and parse_file() entry points
+    visitor.py             # Parse tree -> AST visitor
+    imports.py             # Type/function import resolution
+  interpreter/             # Code execution
+    executor.py            # Top-level evaluator
+    classical/executor.py  # Classical branch evaluator
+    quantum/program.py     # Quantum program execution
+  toolchain/               # Dialect-specific tooling
+    notebooks/             # Jupyter integration (future)
+    pygments/              # Syntax highlighting (future)
+```
+
+See individual README files in each subdirectory for detailed documentation:
+[`code/`](code/README.md) | [`grammar/`](grammar/README.md) | [`parsing/`](parsing/README.md) | [`interpreter/`](interpreter/README.md)
+
+## Compilation and Execution Pipeline
+
+```mermaid
+flowchart LR
+    Source[".hat source"] --> Parser["parsing/run.py\nArpeggio PEG parser"]
+    Parser --> AST["code/ast.py\nHeather AST"]
+    AST --> IRBuilder["code/ir_builder.py"]
+    IRBuilder --> IR["Simple IR\n(IRBlock, IRInstr)"]
+    IR --> Classical["Classical Branch\ninterpreter/classical/"]
+    IR --> Quantum["Quantum Branch\ninterpreter/quantum/"]
+    Quantum --> LLC["Low-Level Language\n(OpenQASM v2)"]
+    LLC --> Backend["Target Backend\n(Qiskit Aer)"]
+    Backend --> Results["Measurement Results"]
+```
+
+## Creating a New Dialect
+
+Heather serves as the reference implementation for H-hat dialects. To create a new dialect, you need:
+
+1. **`grammar/`** -- A PEG grammar file defining your syntax
+2. **`parsing/`** -- An Arpeggio visitor converting parse trees to AST nodes (extending core's `Node`/`Terminal`)
+3. **`code/`** -- AST node classes and an IR builder producing `InstrIR`/`BlockIR`/`BodyIR` instances
+4. **`interpreter/`** -- Concrete `BaseEvaluator` (classical) and `BaseProgram` (quantum) implementations
+
+Any dialect must follow H-hat's rules system: dual-paradigm classification, `@` prefix for quantum identifiers, and the containment rule (quantum can contain classical, but not the reverse).
+
+## Current Status
+
+- **Parsing**: Types (single, struct, enum), imports, identifiers, modifiers, and all literal types work. Function call and array parsing are not yet implemented.
+- **IR Building**: `simple_ir_builder` is functional. SSA IR has data structures defined but is not integrated. MLIR is a stub.
+- **Execution**: Quantum program path works end-to-end (IR -> OpenQASM v2 -> Qiskit Aer -> results). Classical evaluator is a stub.
+- **Toolchain**: Notebooks and Pygments syntax highlighting are placeholders.

--- a/python/src/hhat_lang/dialects/heather/code/README.md
+++ b/python/src/hhat_lang/dialects/heather/code/README.md
@@ -1,0 +1,112 @@
+# Code
+
+Heather-specific AST node definitions and multiple IR builder implementations for converting parsed code into executable intermediate representation.
+
+## Overview
+
+This module defines the full AST vocabulary for Heather (38 node classes), the IR builder that converts AST nodes into core data structures, and three IR backend strategies: a simple IR for the interpreter, an SSA (Static Single Assignment) form IR for future optimization passes, and an MLIR stub for future LLVM integration.
+
+## Directory Structure
+
+```
+code/
+  __init__.py
+  ast.py                      # 38 Heather-specific AST node classes
+  ir_builder.py               # Orchestrates AST -> IR conversion
+  simple_ir_builder/          # Simple (direct) IR implementation
+    __init__.py
+    builder.py                # AST-to-core-data conversion functions
+    ir.py                     # IRInstr, IRBlock, IRArgs, FnIR, IR classes
+  ssa_ir_builder/             # SSA form IR for optimization
+    __init__.py
+    ir.py                     # SSACounter, SSA, SSAPhi, IRModifier, IRVar
+  mlir_builder/               # MLIR target (future)
+    __init__.py
+    ir.py                     # Stub only
+```
+
+## Module Details
+
+### ast.py
+
+Defines the Heather AST node classes, organized by category:
+
+**Identifiers**: `Id` (simple name), `CompositeId` (dotted name like `module.fn`), `CompositeIdWithClosure` (grouped access like `math.{add sub}`), `ModifiedId` (identifier with angle-bracket modifier)
+
+**Literals**: `Literal` (typed literal with value and type strings), `CompositeLiteral` (array of literals)
+
+**Declarations**: `Declare` (type annotation without value), `Assign` (value assignment), `DeclareAssign` (combined annotation + assignment)
+
+**Function calls**: `Call`, `CallArgs`, `CallWithBody` (call with closure), `CallWithBodyOptions`, `CallWithArgsBodyOptions`, `MethodCall`, `MethodCallArgs`, `InsideOption`
+
+**Arguments**: `ArgValuePair` (named arg: value), `OnlyValue` (positional value), `ArgTypePair` (typed arg definition)
+
+**Type definitions**: `TypeDef`, `TypeMember` (named struct member), `SingleTypeMember`, `EnumTypeMember`
+
+**Imports**: `Imports` (container), `TypeImport`, `FnImport`, `ManyTypeImport`
+
+**Structure**: `Modifier`, `Cast`, `Array`, `Hash`, `Expr`, `Body`, `Main`, `FnDef`, `FnArgs`, `Program` (root node)
+
+**Type aliases**: `ValueType`, `TypeType`, `BodyType` for type hinting.
+
+### ir_builder.py
+
+Orchestrates AST-to-IR conversion in three sections:
+
+1. **Building functions** (`_build_id`, `_build_compositeid`, `_build_literal`, `_build_argvaluepair`, `_build_onlyvalue`, `_build_modifier`, `_build_valuetype`, `_build_typetype`, `_build_bodytype`) -- Convert AST nodes into core `Symbol`, `CompositeSymbol`, and `CoreLiteral` objects. Some (like `_build_id`, `_build_literal`, `_build_argvaluepair`) delegate to real implementations in `simple_ir_builder/builder.py`. Others (arrays, hashes, expressions, assignments, function/method calls) are stubs.
+
+2. **Table builders** (`build_typetable`, `build_fntable`) -- Build type and function tables from AST type/function definitions. `build_fntable` extracts function name, return type, arguments, and body.
+
+3. **Main code** (`build_main`) -- Processes the `Program` root node, dispatching on `Imports`, `Body`, `Main`, and `Program` nodes. Calls `parse_imports()` for import resolution.
+
+### simple_ir_builder/
+
+**builder.py** -- Functions that convert AST nodes to core data objects:
+- `define_id(Id) -> Symbol`
+- `define_compositeid(CompositeId) -> CompositeSymbol` (with quantum correctness check)
+- `define_literal(Literal) -> CoreLiteral`
+- `define_argvaluepair(ArgValuePair) -> tuple[Symbol, Any]`
+- `define_valuetype(ValueType) -> Symbol | CompositeSymbol | CoreLiteral`
+
+**ir.py** -- Concrete IR classes implementing core ABCs:
+- `IRInstr(InstrIR)` -- Instruction with name, args, flag
+- `IRArgs(ArgsIR)` -- Argument container
+- `IRBlock(BlockIR)` -- Block with UUID name and `add_instr()` method
+- `FnIR(BaseFnIR)` -- Function table implementation
+- `IR(BaseIR)` -- Top-level IR container with `add_fn()` implementation
+
+### ssa_ir_builder/
+
+**ir.py** -- SSA form data structures for future optimization passes:
+- `SSACounter` -- Manages auto-incrementing version numbers for SSA values. Counter starts at -1 to align with list indexes (first `next()` call returns 0).
+- `SSA` -- Represents a single SSA assignment (symbol + version index). Supports optional `SSAPhi` and `IRModifier`.
+- `SSAPhi` -- Phi function for merging values at control flow join points. Validates that all arguments reference the same variable.
+- `IRModifier` -- Attaches behavioral modifiers to SSA values (positional or key-value)
+- `IRVar` -- Tracks all SSA versions of a single variable (list of `SSA` instances)
+
+### mlir_builder/
+
+**ir.py** -- Contains a single `define_id` stub. Placeholder for future MLIR (Multi-Level IR) integration with LLVM-based backends.
+
+```mermaid
+flowchart TD
+    AST["Heather AST\n(Program, Id, Literal, ...)"]
+    AST --> IRBuilder["ir_builder.py"]
+    IRBuilder --> Simple["simple_ir_builder/\n(IR, IRBlock, IRInstr)"]
+    IRBuilder -.->|"future"| SSA["ssa_ir_builder/\n(SSA, SSAPhi, IRVar)"]
+    IRBuilder -.->|"future"| MLIR["mlir_builder/\n(stub)"]
+    Simple --> Eval["Interpreter\n(Evaluator / Program)"]
+```
+
+## Connections
+
+- **[`../parsing/`](../parsing/)**: Produces the AST that `ir_builder.py` consumes
+- **[`hhat_lang.core.code`](../../../core/code/)**: Provides the ABCs that simple_ir_builder implements (InstrIR, BlockIR, ArgsIR, BaseFnIR, BaseIR)
+- **[`hhat_lang.core.data`](../../../core/data/)**: `Symbol`, `CompositeSymbol`, `CoreLiteral` produced by the builder functions
+- **[`../interpreter/`](../interpreter/)**: Consumes the IR for execution
+
+## Current Status
+
+`simple_ir_builder` is the most complete IR backend -- `IRInstr`, `IRBlock`, `IRArgs`, `FnIR`, and `IR` are all implemented. `ssa_ir_builder` has the SSA data structures defined but is not yet integrated into `ir_builder.py`. `mlir_builder` is a stub. Many `_build_*` functions in `ir_builder.py` are stubs (arrays, hashes, expressions, assignments, function/method calls).
+
+The IR backend is intended to be swappable -- `ir_builder.py` has a TODO to support selecting which backend (simple, SSA, MLIR) to use via a project configuration file, rather than the current hardcoded `simple_ir_builder` import.

--- a/python/src/hhat_lang/dialects/heather/grammar/README.md
+++ b/python/src/hhat_lang/dialects/heather/grammar/README.md
@@ -1,0 +1,92 @@
+# Grammar
+
+Defines the Heather dialect's syntax using a PEG (Parsing Expression Grammar), processed by the [Arpeggio](https://github.com/textX/Arpeggio) parser library.
+
+## Overview
+
+Heather uses a declarative PEG grammar file to specify its syntax. The Arpeggio parser reads this grammar at runtime and produces a parse tree, which the [`../parsing/`](../parsing/) module then converts into AST nodes.
+
+## Directory Structure
+
+```
+grammar/
+  __init__.py      # WHITESPACE definition
+  grammar.peg      # Complete PEG grammar for the Heather dialect
+```
+
+## Module Details
+
+### `__init__.py`
+
+Defines `WHITESPACE = "\n\t ,;"`. In Heather, commas and semicolons are treated as whitespace alongside newlines, tabs, and spaces. This is an intentional design choice: by making commas and semicolons part of whitespace, they become optional separators everywhere. You can write `fn(a b c)` or `fn(a, b, c)` -- both are valid. This reduces syntactic noise and avoids common "missing comma" errors, while still allowing programmers who prefer delimiters to use them.
+
+### grammar.peg
+
+The full PEG grammar, organized into these rule groups:
+
+**Program structure**
+- `program` -- Top-level: imports, type definitions, functions, and an optional `main` block
+- `imports` -- `use(type: ... fn: ...)` import declarations
+- `main` -- `main { ... }` entry point block
+
+**Type definitions**
+- `type_file` -- `type` keyword followed by one of four forms:
+  - `typesingle` -- `name : type` (single-member alias)
+  - `typestruct` -- `name { member1: type1  member2: type2 }` (struct with named members)
+  - `typeenum` -- `name { Variant1  Variant2 }` (enum with variants)
+  - `typeunion` -- `name union { member1: type1 }` (tagged union)
+- `type_trait` -- `trait name { fns }` (trait definition)
+- `typespace` -- `typespace name { fns }` (type namespace)
+
+**Functions**
+- `fns` -- `fn name (args) return_type? { body }`
+- `fnargs` -- `(arg_name: arg_type ...)`
+- `return` -- `= expr` (return expression)
+
+**Expressions and statements**
+- `body` -- `{ declare | assign | declareassign | expr ... }`
+- `expr` -- One of: cast, call, callwithbody, callwithbodyoptions, callwithargsbodyoptions, array, id, literal
+- `declare` -- `name<modifier>?: type` (variable declaration)
+- `assign` -- `id = expr` (assignment)
+- `declareassign` -- `name<modifier>?: type = expr` (combined declare+assign)
+- `cast` -- `expr * type` (type casting, e.g., `u32*@2`)
+
+**Function calls**
+- `call` -- `trait#id.fn(args)` or `fn(args)` (basic call)
+- `callwithbody` -- `fn { body }` (call with closure)
+- `callwithbodyoptions` -- `fn(args) { body }` (call with args and closure)
+- `callwithargsbodyoptions` -- `fn(expr { body } ...)` (call with expression-body pairs)
+
+**Identifiers**
+- `simple_id` -- `@?[a-zA-Z][a-zA-Z0-9\-_]*` (optional `@` prefix for quantum)
+- `composite_id` -- `a.b.c` (dotted identifier)
+- `composite_id_with_closure` -- `a.{b c d}` (grouped attribute access)
+- `modifier` -- `<value ...>` or `<name: value ...>` (angle-bracket modifiers)
+- `trait_id` -- `Type#trait` (trait accessor)
+
+**Literals**
+- Classical: `null`, `bool` (`true`/`false`), `str` (`"..."`), `int`, `float`, `imag`, `complex` (`[real imag]`)
+- Quantum: `q__bool` (`@true`/`@false`), `q__int` (`@42`, `@0`)
+
+**Comments**
+- Single-line: `// ...`
+- Multi-line: `/- ... -/`
+
+## Connections
+
+- **[`../parsing/run.py`](../parsing/run.py)**: Loads `grammar.peg` via `read_grammar()` and creates an Arpeggio `ParserPEG` instance with `program` as the root rule and `comment` as the comment rule
+- **[`../parsing/visitor.py`](../parsing/visitor.py)**: Each grammar rule maps to a `visit_*` method in `ParserVisitor`
+
+## Modifying the Grammar
+
+The grammar is loaded at runtime by `parsing/run.py` via `read_grammar()`. To add or modify syntax rules:
+
+1. Edit `grammar.peg` following PEG syntax (ordered choice with `/`, sequences with spaces, optional with `?`, repetition with `*`/`+`)
+2. Add a corresponding `visit_<rule_name>` method in `parsing/visitor.py` that converts the parse tree node to a Heather AST node
+3. If the rule produces a new AST node type, define it in `code/ast.py`
+
+Arpeggio processes the grammar top-down from the `program` root rule. The `comment` rule is automatically handled as a comment pattern and stripped from the parse tree.
+
+## Current Status
+
+The grammar covers the current feature set: imports, type definitions (single/struct/enum), function definitions, variable declarations and assignments, casting, and literals. Some corresponding visitor methods are not yet implemented (function calls, arrays, trait identifiers, union types).

--- a/python/src/hhat_lang/dialects/heather/interpreter/README.md
+++ b/python/src/hhat_lang/dialects/heather/interpreter/README.md
@@ -1,0 +1,119 @@
+# Interpreter
+
+Executes Heather IR code through a dual-branch architecture: classical instructions run directly via an evaluator, quantum instructions are compiled to a low-level quantum language and executed on a target backend.
+
+## Overview
+
+H-hat's execution model splits IR code into two branches based on the data paradigm. The classical branch evaluates standard operations using memory, types, and function tables. The quantum branch generates low-level quantum code (e.g., OpenQASM), executes it on a target backend (e.g., Qiskit Aer simulator), and casts the results back to the requested classical type.
+
+The execution pipeline (from `__init__.py`):
+
+```
+raw code -> AST -> IR
+              _______|__________
+             |                  |
+             v                  v
+       quantum branch      classical branch
+             |                  |-> memory
+             |                  |-> executor
+             |-> program
+             |-> executor
+                     | -> low level language
+                     | -> target (simulator or QPU device)
+                     | -> classical branch (if needed)
+```
+
+## Directory Structure
+
+```
+interpreter/
+  __init__.py                  # Execution pipeline documentation
+  executor.py                  # Top-level Evaluator (accepts full IR)
+  classical/
+    __init__.py
+    executor.py                # Classical branch Evaluator (BaseEvaluator impl)
+  quantum/
+    __init__.py
+    program.py                 # Quantum Program (BaseProgram impl)
+```
+
+## Module Details
+
+### executor.py
+
+**`Evaluator`** -- Top-level evaluator that accepts a `BaseIR` instance. Validates the input type at construction. Has `walk()` and `run()` methods -- both are currently stubs. Intended to orchestrate the branching between classical and quantum execution paths.
+
+### classical/executor.py
+
+**`Evaluator(BaseEvaluator)`** -- Classical branch evaluator. Constructed with:
+- `mem` -- `MemoryManager` for variable storage, stack, and heap operations
+- `type_table` -- `TypeIR` with all registered type definitions
+- `fn_table` -- `BaseFnIR` with all registered function definitions
+
+Methods `run(code: BodyIR | BlockIR)` and `__call__(code: BodyIR | BlockIR)` are stubs. This evaluator is also used as a fallback by the quantum branch for instructions that the low-level language or target backend doesn't support.
+
+### quantum/program.py
+
+**`Program(BaseProgram)`** -- The most complete execution component. Handles quantum data execution and casting between quantum and classical types.
+
+Constructed with (keyword-only arguments):
+- `qdata` -- The quantum variable (`WorkingData`) being processed
+- `idx` -- `IndexManager` for qubit allocation tracking
+- `block` -- `IRBlock` containing the quantum instructions
+- `executor` -- `BaseEvaluator` for classical fallback
+- `qlang` -- A `BaseLowLevelQLang` class (not instance) to generate low-level code
+
+The constructor instantiates the low-level language with the quantum data, IR block, index manager, evaluator, and a fresh `Stack` for the quantum execution context.
+
+**`run(debug=False)`**:
+1. Calls `self._qlang.gen_program()` to produce the complete low-level code (e.g., an OpenQASM v2 program string)
+2. If `debug`, prints the generated code
+3. Calls `execute_program()` from the target backend to run the circuit and return measurement results
+
+Example quantum casting workflows:
+```
+u32*@2              // cast quantum literal @2 to u32
+u32*@redim(@1<@u3>) // cast quantum operation result to u32
+@v1:@u3 = @redim(@0)
+number:u32 = u32*@v1  // cast quantum variable to u32
+```
+
+> **Note**: The target backend import (`qiskit.openqasm.code_executor`) is currently hardcoded. This should be driven by project configuration.
+
+```mermaid
+flowchart TB
+    IR["IR (BaseIR)"]
+    IR --> TopEval["executor.py\nEvaluator (stub)"]
+    TopEval --> Classical["classical/executor.py\nEvaluator"]
+    TopEval --> Quantum["quantum/program.py\nProgram"]
+
+    Classical -->|"BodyIR / BlockIR"| Mem["MemoryManager"]
+
+    Quantum -->|"gen_program()"| QLang["BaseLowLevelQLang\n(e.g., OpenQASM v2)"]
+    QLang -->|"QASM code"| Backend["Target Backend\n(e.g., Qiskit Aer)"]
+    Backend -->|"measurement counts"| Results["Results"]
+
+    Quantum -.->|"fallback"| Classical
+```
+
+## Connections
+
+- **[`../code/`](../code/)**: Provides the IR that the interpreter executes
+- **[`hhat_lang.core.execution`](../../../core/execution/)**: `BaseEvaluator` and `BaseProgram` ABCs that the classical executor and quantum program implement
+- **[`hhat_lang.core.memory`](../../../core/memory/)**: `MemoryManager`, `IndexManager`, `Stack` used by both branches
+- **[`hhat_lang.low_level`](../../../low_level/)**: OpenQASM v2 backend (`LowLeveQLang`) and Qiskit execution (`execute_program`)
+
+## Design Notes
+
+**Stack ordering for control flow**: Instructions that consume multiple arguments from the stack (like `if`) expect a specific push order. For `If`, the condition is pushed first and the instruction body second. Since the stack is LIFO, pops retrieve them in reverse: body first, then condition. Getting this order wrong causes silent misinterpretation. See the `If` instruction in `low_level/quantum_lang/openqasm/v2/instructions.py` for the canonical example.
+
+**Quantum program workflow** (documented in `program.py`):
+1. Instructions are analyzed against what the low-level language and target backend support
+2. Unsupported classical instructions fall back to the dialect's classical evaluator
+3. Memory is managed by the dialect but shared with low-level counterparts
+4. Quantum optimizations are handled by the low-level compiler (future)
+5. Quantum instructions are executed, and casting protocols convert results from quantum to classical types
+
+## Current Status
+
+The quantum program execution path works end-to-end: IR -> OpenQASM v2 code generation -> Qiskit Aer simulation -> measurement results. The top-level evaluator and classical branch evaluator are stubs (`run()` and `__call__()` are no-ops).

--- a/python/src/hhat_lang/dialects/heather/parsing/README.md
+++ b/python/src/hhat_lang/dialects/heather/parsing/README.md
@@ -1,0 +1,81 @@
+# Parsing
+
+Parses Heather `.hat` source code into AST nodes using the Arpeggio PEG parser, and handles import resolution.
+
+## Overview
+
+This module is the entry point for transforming raw Heather source code into an abstract syntax tree. The pipeline is: read grammar -> create parser -> parse source -> visit parse tree -> produce AST. A separate import resolution step handles `use(type: ...)` statements by locating and loading type definitions from the project's `hat_types/` directory.
+
+## Directory Structure
+
+```
+parsing/
+  __init__.py
+  run.py          # Parser instantiation and entry points (parse, parse_file)
+  visitor.py      # ParserVisitor: parse tree -> Heather AST conversion
+  imports.py      # Import resolution for types and functions
+```
+
+## Module Details
+
+### run.py
+
+Entry point functions for the parsing pipeline:
+
+- **`read_grammar()`** -- Loads `grammar.peg` from the grammar directory. Raises `ValueError` if not found.
+- **`parse_grammar()`** -- Creates an Arpeggio `ParserPEG` with root rule `program`, comment rule `comment`, `reduce_tree=False`, and `ws=WHITESPACE` (Heather's whitespace characters). The `reduce_tree=False` setting is important: it preserves the full parse tree structure rather than collapsing single-child nodes. This gives the visitor deterministic node structures to pattern-match against, at the cost of more verbose tree traversal.
+- **`parse(raw_code: str) -> AST`** -- Full pipeline: creates parser, parses the source string, then applies `ParserVisitor` via `visit_parse_tree()` to produce a Heather AST.
+- **`parse_file(file: str | Path) -> AST`** -- Convenience wrapper that reads a file and calls `parse()`.
+
+### visitor.py
+
+**`ParserVisitor(PTNodeVisitor)`** -- Arpeggio visitor that converts each grammar rule match into a Heather AST node. Each `visit_*` method corresponds to a rule in `grammar.peg`:
+
+| Visitor method | Produces AST node | Notes |
+|---------------|-------------------|-------|
+| `visit_program` | `Program` | Collects imports, types, functions, main |
+| `visit_imports` | `Imports` | Groups type and function imports |
+| `visit_typeimport` | `TypeImport` | List of imported type identifiers |
+| `visit_typesingle` | `TypeDef` + `SingleTypeMember` | Single-member type alias |
+| `visit_typestruct` | `TypeDef` + `TypeMember` list | Struct with named fields |
+| `visit_typeenum` | `TypeDef` + `EnumTypeMember` list | Enum with variants |
+| `visit_id` | `Id` or `ModifiedId` | Identifier, with modifier if present |
+| `visit_composite_id` | `CompositeId` | Dotted identifier |
+| `visit_composite_id_with_closure` | `CompositeIdWithClosure` | Grouped attribute access |
+| `visit_modifier` | `Modifier` | Angle-bracket modifier |
+| `visit_main` | `Main` | Main entry block |
+| `visit_literal`, `visit_int`, `visit_bool`, etc. | `Literal` | Typed literal values |
+| `visit_q__bool`, `visit_q__int` | `Literal` | Quantum literals (`@true`, `@42`) |
+
+**Not yet implemented** (raise `NotImplementedError`): `visit_call`, `visit_args`, `visit_callargs`, `visit_valonly`, `visit_array`, `visit_trait_id`, `visit_typeunion`.
+
+### imports.py
+
+Handles `use(type: ...)` import statements:
+
+- **`parse_imports(code: Imports)`** -- Entry point. Extracts `TypeImport` entries, resolves each imported type name to a `CompositeSymbol`, then creates a `TypeImporter` instance and calls `import_types()` to recursively resolve all dependencies.
+- **`parse_types(code)`** -- Dispatches on `CompositeId` or `CompositeIdWithClosure` to collect symbol lists.
+- **`_collect_symbols_from_closure(obj, prefix)`** -- Recursively expands grouped import syntax (e.g., `math.{vector matrix}` becomes `[CompositeSymbol(("math", "vector")), CompositeSymbol(("math", "matrix"))]`).
+- **`parse_fns(code)`** -- Function import handling (stub, not implemented).
+
+```mermaid
+flowchart LR
+    Source[".hat source"] --> parse["parse()"]
+    parse --> Grammar["grammar.peg\n(Arpeggio PEG)"]
+    Grammar --> PT["Parse Tree"]
+    PT --> Visitor["ParserVisitor"]
+    Visitor --> AST["Heather AST\n(Program node)"]
+    AST --> ImportRes["imports.py"]
+    ImportRes --> TI["TypeImporter\n(core/imports/)"]
+```
+
+## Connections
+
+- **[`../grammar/`](../grammar/)**: Provides `grammar.peg` and `WHITESPACE` definition
+- **[`../code/ast.py`](../code/ast.py)**: The AST node classes that the visitor produces
+- **[`../code/ir_builder.py`](../code/ir_builder.py)**: Consumes the AST for IR construction
+- **[`hhat_lang.core.imports`](../../../core/imports/)**: `TypeImporter` resolves transitive type dependencies
+
+## Current Status
+
+Parsing works for types (single, struct, enum), imports, identifiers, modifiers, and all literal types. Function call parsing, array parsing, trait identifiers, and union types are not yet implemented in the visitor.

--- a/python/src/hhat_lang/low_level/quantum_lang/README.md
+++ b/python/src/hhat_lang/low_level/quantum_lang/README.md
@@ -1,0 +1,110 @@
+# Quantum Language Backends
+
+Implementations of low-level quantum language backends that translate H-hat quantum instructions into specific quantum assembly languages.
+
+## Overview
+
+When the Heather interpreter encounters quantum instructions, it delegates code generation to a low-level quantum language backend. Each backend implements `BaseLowLevelQLang` (from [`core/lowlevel/`](../../core/lowlevel/)) and translates H-hat IR instructions into a target language (e.g., OpenQASM v2). The backend also defines the concrete quantum instruction classes that map H-hat operations to hardware-level gates.
+
+## Directory Structure
+
+```
+quantum_lang/
+  __init__.py
+  openqasm/                   # OpenQASM backend
+    __init__.py               # DEFAULT_HEADER constant
+    v2/                       # OpenQASM v2.0 implementation
+      __init__.py
+      qlang.py                # LowLeveQLang class (main backend)
+      instructions.py         # Instruction classes (QRedim, QSync, QNot, QNez, If)
+  netqasm/                    # NetQASM backend (placeholder)
+    __init__.py
+```
+
+## Module Details
+
+### openqasm/v2/qlang.py
+
+**`LowLeveQLang(BaseLowLevelQLang)`** -- The main OpenQASM v2.0 backend. Generates complete QASM programs from H-hat IR.
+
+Key methods:
+
+| Method | Purpose |
+|--------|---------|
+| `init_qlang()` | Returns QASM header: version declaration, `qelib1.inc` include, `qreg`/`creg` declarations |
+| `end_qlang()` | Returns `measure q -> c;` measurement instruction |
+| `gen_literal(literal)` | Converts a `CoreLiteral`'s binary representation to Pauli-X gates (each `1` bit becomes `x q[n];`) |
+| `gen_var(var, executor)` | Recursively resolves variable data from the heap and generates code for each member (Symbol, CoreLiteral, or nested InstrIR) |
+| `gen_args(args)` | Iterates over instruction arguments, dispatching each to `gen_literal`, `gen_var`, or `gen_instrs` |
+| `gen_instrs(instr)` | Dynamically imports instruction classes via `inspect.getmembers()`, matches `InstrIR.name` to the class's `name` attribute, handles `SKIP_GEN_ARGS` flag for special instructions like `@nez` |
+| `gen_program()` | Full pipeline: iterates IR block instructions, generates arguments and instruction code, assembles header + body + measurements into a complete QASM string |
+
+The instruction dispatch uses Python's `importlib` and `inspect` to dynamically discover instruction classes, matching each IR instruction's name against available classes at runtime. This means adding a new instruction is purely additive -- define a new class in `instructions.py` with a matching `name` attribute, and `gen_instrs()` will find it automatically without any registration step.
+
+### openqasm/v2/instructions.py
+
+Concrete instruction classes that translate H-hat operations to OpenQASM v2 gate instructions:
+
+**Classical instructions:**
+
+| Class | H-hat name | QASM output | Description |
+|-------|-----------|-------------|-------------|
+| `If` | `if` | `if(cond) instr;` | Classical conditional. Pops condition and instruction from the executor's stack. |
+
+**Quantum instructions:**
+
+| Class | H-hat name | QASM output | Description |
+|-------|-----------|-------------|-------------|
+| `QRedim` | `@redim` | `h q[idx];` | Hadamard gate -- puts qubit into superposition |
+| `QSync` | `@sync` | `cx q[idx0], q[idx1];` | CNOT gate -- entangles two qubits |
+| `QNot` | `@not` | `x q[idx];` | Pauli-X gate -- quantum NOT |
+| `QNez` | `@nez` | (varies) | Not-equal-zero conditional: applies a body instruction only to qubits where the mask has `1` bits. Uses `SKIP_GEN_ARGS` flag for custom argument handling. |
+| `QIf` | `@if` | -- | Quantum conditional (stub, raises `NotImplementedError`) |
+
+**`QNez` in detail:** This instruction takes a mask and a body instruction (e.g., `@nez(@5, @not)`). It converts the mask to binary, identifies which bit positions are `1`, selects the corresponding qubit indexes, and applies the body instruction only to those qubits. Supports `CoreLiteral`, `Symbol`, and `BaseDataContainer` as mask values, resolving variables from the executor's heap when needed.
+
+Each instruction returns `tuple[tuple[str, ...], InstrStatus]` -- a tuple of QASM code strings and the resulting status (`DONE` or `ERROR`).
+
+### Adding a New Instruction
+
+1. Inherit from `QInstr` (quantum) or `CInstr` (classical) from `core/code/instructions.py`
+2. Set a `name` class attribute matching the H-hat instruction name (e.g., `name = "@redim"`)
+3. Implement a static `_instr()` method that returns the QASM template string
+4. Implement `_translate_instrs()` for any conversion logic
+5. Implement `__call__(*, idxs, executor, **kwargs)` as the main entry point
+6. If your instruction needs custom argument handling instead of standard `gen_args()` processing, set `flag = QInstrFlag.SKIP_GEN_ARGS` (see `QNez` for an example)
+
+### netqasm/
+
+Placeholder for a future [NetQASM](https://github.com/QuTech-Delft/netqasm) backend, intended for quantum network applications. Currently contains only an empty `__init__.py`.
+
+```mermaid
+flowchart TD
+    IR["H-hat IR\n(IRBlock with InstrIR)"]
+    IR --> QLang["LowLeveQLang"]
+    QLang -->|"gen_args()"| Args["Argument Generation\n(gen_literal / gen_var)"]
+    QLang -->|"gen_instrs()"| Dispatch["Dynamic Dispatch\n(importlib + inspect)"]
+    Dispatch --> QRedim["QRedim\n→ h q[n];"]
+    Dispatch --> QSync["QSync\n→ cx q[a],q[b];"]
+    Dispatch --> QNot["QNot\n→ x q[n];"]
+    Dispatch --> QNez["QNez\n→ masked body instr"]
+    Dispatch --> If["If\n→ if(c) instr;"]
+    QLang -->|"gen_program()"| QASM["Complete OpenQASM v2\nprogram string"]
+```
+
+## Connections
+
+- **[`../../core/lowlevel/abstract_qlang.py`](../../core/lowlevel/abstract_qlang.py)**: `BaseLowLevelQLang` ABC that `LowLeveQLang` implements
+- **[`../../core/code/instructions.py`](../../core/code/instructions.py)**: `QInstr` and `CInstr` base classes for the instruction implementations
+- **[`../target_backend/`](../target_backend/)**: Takes the generated QASM string and executes it on a simulator or device
+- **[`../../dialects/heather/interpreter/quantum/program.py`](../../dialects/heather/interpreter/quantum/program.py)**: Creates a `LowLeveQLang` instance and calls `gen_program()`
+
+## Current Status
+
+OpenQASM v2 backend is functional with `@redim` (Hadamard), `@sync` (CNOT), `@not` (Pauli-X), `@nez` (masked conditional), and classical `if`. `@if` (quantum conditional) is a stub. Composite data types (`CompositeSymbol`, `CompositeLiteral`, `CompositeMixData`) in `gen_var` and `gen_args` raise `NotImplementedError`. NetQASM is a placeholder.
+
+Open TODOs in the backend:
+- `end_qlang()`: Track previously-measured qubits to avoid redundant measurement
+- `gen_program()`: When an instruction isn't supported by OpenQASM v2, fall back to the dialect's classical executor instead of failing
+- `@sync`: Extend beyond basic 2-qubit CX to full multi-qubit sync capabilities
+- Error handling in `gen_program()` needs proper recovery beyond raising exceptions

--- a/python/src/hhat_lang/low_level/target_backend/README.md
+++ b/python/src/hhat_lang/low_level/target_backend/README.md
@@ -1,0 +1,60 @@
+# Target Backends
+
+Execution backends that take generated quantum language code and run it on simulators or quantum hardware, returning measurement results.
+
+## Overview
+
+After the quantum language backend (e.g., OpenQASM v2) produces a program string, a target backend compiles it into a runnable circuit, executes it, and returns the measurement results as bitstring distributions. Currently, the only implemented backend uses Qiskit with the Aer simulator.
+
+## Directory Structure
+
+```
+target_backend/
+  __init__.py
+  qiskit/                     # Qiskit-based backend
+    __init__.py
+    openqasm/
+      __init__.py
+      code_executor.py        # Circuit loading, sampling, and execution
+  squidasm/                   # SquidASM backend (placeholder)
+    __init__.py
+```
+
+## Module Details
+
+### qiskit/openqasm/code_executor.py
+
+Three functions forming the execution pipeline:
+
+**`load_qasm(code: str) -> QuantumCircuit`**
+Parses an OpenQASM v2.0 string into a Qiskit `QuantumCircuit` using `qasm2.loads()`.
+
+**`sample_circuit(circuit, qdata, metadata=None) -> counts | ErrorHandler`**
+Executes the circuit on the Aer simulator and returns measurement counts:
+1. Creates an `AerSimulator` backend
+2. Transpiles the circuit for backend compatibility
+3. Creates a `SamplerV2` instance
+4. Runs with configurable shot count (default: `num_qregs * 888`). The `888` multiplier is an arbitrary default -- callers can override via `metadata["shots"]`. More shots give more precise probability distributions but take longer.
+5. Extracts counts from the `DataBin` result object
+6. Returns a `Counter`-like dict mapping bitstrings to counts, or `InvalidQuantumComputedResult` on failure
+
+**`execute_program(code: str, qdata, debug=False) -> counts | ErrorHandler`**
+End-to-end execution: calls `load_qasm()` then `sample_circuit()`. If `debug` is `True`, prints the results. Returns the bitstring distribution or an error.
+
+### squidasm/
+
+Placeholder for a future [SquidASM](https://github.com/QuTech-Delft/squidasm) backend, intended for quantum network simulation. Currently contains only an empty `__init__.py`.
+
+## Connections
+
+- **[`../quantum_lang/`](../quantum_lang/)**: Produces the QASM code string that this module executes
+- **[`../../dialects/heather/interpreter/quantum/program.py`](../../dialects/heather/interpreter/quantum/program.py)**: Calls `execute_program()` after `gen_program()` produces the QASM code
+- **[`../../core/error_handlers/`](../../core/error_handlers/)**: Returns `InvalidQuantumComputedResult` when execution fails
+
+## Design Notes
+
+The backend is currently hardcoded to `AerSimulator` (a local simulator). There is a TODO to make this configurable via project settings, which would allow switching to real quantum hardware (IBM Quantum), different simulators, or other providers. The error handling after a failed quantum computation also needs a proper recovery strategy beyond the current minimal handling.
+
+## Current Status
+
+Qiskit/Aer backend is functional. Uses a hardcoded `AerSimulator` -- configurable backend selection (real hardware, different simulators) is a TODO. SquidASM is a placeholder.

--- a/python/src/hhat_lang/toolchain/README.md
+++ b/python/src/hhat_lang/toolchain/README.md
@@ -1,0 +1,88 @@
+# Toolchain
+
+Command-line interface and project management utilities for creating and running H-hat projects.
+
+## Overview
+
+The toolchain provides the `hat` CLI command, built with [Typer](https://typer.tiangolo.com/) and styled with [Rich](https://rich.readthedocs.io/). It supports creating new H-hat projects with the required directory structure, creating new source and type files, and running projects.
+
+## Directory Structure
+
+```
+toolchain/
+  __init__.py
+  cli/
+    __init__.py
+    cli.py            # Typer CLI app with hat commands (new, run, help)
+  project/
+    __init__.py
+    new.py            # Project and file creation
+    run.py            # Project execution (not yet implemented)
+    update.py         # Project updates (not yet implemented)
+    utils.py          # str_to_path utility
+  notebooks/          # Jupyter integration (placeholder)
+    __init__.py
+```
+
+## Module Details
+
+### cli/cli.py
+
+Defines the `hat` CLI application:
+
+**`hat --version` / `hat -v`** -- Prints the version (0.1.0) and exits.
+
+**`hat new <project_name>`** -- Creates a new H-hat project with the standard directory template:
+```
+project_name/
+  src/
+    main.hat            # Entry point
+    hat_types/          # Type definition files
+    hat_docs/
+      main.hat.md       # Documentation for main.hat
+      hat_types/        # Documentation for type files
+  tests/
+```
+
+**`hat new -f <file_name>`** -- Creates a new `.hat` file and its corresponding documentation file within an existing project. Must be run from within a project directory (one containing `src/main.hat`).
+
+**`hat new -t <type_file>`** -- Creates a new type definition file in `src/hat_types/` with a matching documentation file.
+
+**`hat run`** -- Runs the current project (locates `src/main.hat` via `get_proj_dir()`). Currently calls `run_project()`, which is not yet implemented.
+
+**`hat help [command]`** -- Shows available commands or detailed help for a specific command.
+
+**`get_proj_dir()`** -- Searches upward from the current directory for a folder containing `src/main.hat` to locate the project root. Raises `ValueError` if not found.
+
+### project/new.py
+
+- **`create_new_project(project_name)`** -- Creates the full project directory template (folders and files). Note: there is a commented-out `proofs/` directory in the template -- once formal verification is incorporated into H-hat, this will be re-enabled.
+- **`create_new_file(project_name, file_name)`** -- Creates a `.hat` file and its `hat_docs/` documentation counterpart
+- **`create_new_type_file(project_name, file_name)`** -- Creates a type file in `hat_types/` and its documentation
+
+### project/run.py
+
+**`run_project()`** -- Stub. Raises `NotImplementedError`. Intended to parse `main.hat`, build IR, and execute via the dialect's interpreter.
+
+### project/update.py
+
+**`update_project(project_name)`** -- Stub. Intended for updating/regenerating documentation files for existing project files.
+
+### project/utils.py
+
+**`str_to_path(obj)`** -- Converts a `str` or `Path` to a resolved `Path` object.
+
+## Connections
+
+- **[`../dialects/heather/parsing/`](../dialects/heather/parsing/)**: `run_project()` will use the dialect's parser to process `.hat` files
+- **[`../dialects/heather/interpreter/`](../dialects/heather/interpreter/)**: `run_project()` will use the dialect's evaluator for execution
+
+## Design Notes
+
+**Project discovery**: `get_proj_dir()` searches upward from the current working directory for a folder containing `src/main.hat`. This means all `hat` commands that operate on a project (like `hat run`) can be invoked from any subdirectory within the project, similar to how `git` finds the `.git` directory.
+
+**Documentation pairing**: Every `.hat` source file gets a corresponding `.hat.md` documentation file under `hat_docs/`. The `hat new -f` and `hat new -t` commands automatically create both, enforcing this convention from the start.
+
+## Current Status
+
+Project creation (`hat new`) is fully functional. The CLI framework is in place with proper error handling and styled output. `hat run` and project updates are not yet implemented.


### PR DESCRIPTION
  ## Summary
  - Add 16 new README.md files and update 1 existing across python/src/hhat_lang/ subfolders
  - Each README covers: module purpose, directory structure, file/class breakdowns, Mermaid diagrams, cross-references, and current status
  - Includes design rationale, developer guidance (how to add instructions/backends/dialects), and surfaced TODOs from code
  
Closes - #93 