### PR TITLE
Fix code blocks white stripes and missing logo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,3 @@ jobs:
         with:
           python-version: 3.12
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material mkdocstrings markdown-exec
-      - run: mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-
+  
 # H-hat Quantum Language
 
 [![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg)](https://unitary.foundation)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,13 +4,22 @@
 [![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg)](https://unitary.foundation)
 [![Discord Chat](https://img.shields.io/badge/dynamic/json?color=blue&label=Discord&query=approximate_presence_count&suffix=%20online.&url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FJqVGmpkP96%3Fwith_counts%3Dtrue)](http://discord.unitary.foundation)
 
+
+<figure markdown="span">
+  [![logo_light.png](assets/logo_light.png#only-light){ width=20%}](assets/ATTRIBUTION.md "H-hat logo")
+  [![logo_dark.png](assets/logo_dark.png#only-dark){ width=20%}](assets/ATTRIBUTION.md "H-hat logo")
+</figure>
+
+
+H-hat is a rule system, compiler framework, and a statically typed, functional and distributed system inspired, quantum programming language.
+
+---
+
 !!! warning
 
     This is a work in progress and may be seeing as such. Errors, inconsistencies,
     tons of experimentation are modifications are happening. Until the version 0.3 is released, it is prone to breaking changes.
 
-
-H-hat is a rule system, compiler framework, and a statically typed, functional and distributed system inspired, quantum programming language.
 
 It aims to support explicit function overloading, algebraic data types, ownership and RAII-like features, strict and lazy evaluation, reflective cast, metaprogramming, structured typing-like approach, concurrency, backend kind-based types (CPU and QPU), and multi-architecture targeting computation (e.g. CPU: x86_64, aarch64; gate- and analog-based QPU: superconducting, trapped ion, neutral atoms, photonics, etc.)
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -158,3 +158,14 @@ code {
 [data-md-color-scheme="slate"] .md-header__button.md-logo img {
   content: url("../assets/icon_dark.svg");
 }
+
+/* IMAGE DEFAULT & SLATE */
+[data-md-color-scheme="default"] img[src$="#only-dark"],
+[data-md-color-scheme="default"] img[src$="#gh-dark-mode-only"] {
+  display: none; /* Hide dark images in light mode */
+}
+
+[data-md-color-scheme="slate"] img[src$="#only-light"],
+[data-md-color-scheme="slate"] img[src$="#gh-light-mode-only"] {
+  display: none; /* Hide light images in dark mode */
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: H-hat quantum programming language
 site_url: https://docs.hhat-lang.org/
+site_author: H-hat team
+site_description: H-hat is a rule system, compiler framework, and a statically typed, functional and distributed system inspired, quantum programming language.
+
 repo_url: "https://github.com/hhat-lang/hhat_lang/"
 repo_name: hhat-lang/hhat_lang
 
@@ -76,6 +79,7 @@ markdown_extensions:
 
 plugins:
   - search
+  - social
   - hhat-heather-pygments
   - blog:
       blog_toc: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,6 @@ markdown_extensions:
       linenums_style: pymdownx.inline
       line_spans: __span
       pygments_lang_class: true
-      use_pygments: true
       noclasses: false
   - pymdownx.superfences:
       custom_fences:
@@ -80,7 +79,6 @@ markdown_extensions:
 plugins:
   - search
   - social
-  - hhat-heather-pygments
   - blog:
       blog_toc: true
       post_date_format: full

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -68,7 +68,7 @@ dev = [
     "isort",
     "pre-commit",
     "mkdocs",
-    "mkdocs-material",
+    "mkdocs-material[imaging]",
     "mkdocs-autoapi",
     "mkdocstrings",
     "markdown",

--- a/python/src/hhat_lang/dialects/heather/toolchain/pygments/mkdocs_plugin.py
+++ b/python/src/hhat_lang/dialects/heather/toolchain/pygments/mkdocs_plugin.py
@@ -12,8 +12,7 @@ class HhatCssPlugin(BasePlugin):
         ("light_style", c.Type(str, default="hhat_heather_light")),
         ("dark_style", c.Type(str, default="hhat_heather_dark")),
         ("light_scheme", c.Type(str, default="default")),  # Material light scheme name
-        ("dark_scheme", c.Type(str, default="slate")),     # Material dark scheme name
-        ("css_path", c.Type(str, default="stylesheets/hhat-heather-pygments.css")),
+        ("dark_scheme", c.Type(str, default="slate")),  # Material dark scheme name
         ("selector", c.Type(str, default=".highlight")),
     )
 
@@ -24,15 +23,15 @@ class HhatCssPlugin(BasePlugin):
 
         # Scope each generated stylesheet to Material's scheme attribute selector:
         light_sel = f'[data-md-color-scheme="{self.config["light_scheme"]}"] {self.config["selector"]}'
-        dark_sel  = f'[data-md-color-scheme="{self.config["dark_scheme"]}"] {self.config["selector"]}'
+        dark_sel = f'[data-md-color-scheme="{self.config["dark_scheme"]}"] {self.config["selector"]}'
 
-        light_css = HtmlFormatter(style=self.config["light_style"]).get_style_defs(light_sel)
-        dark_css  = HtmlFormatter(style=self.config["dark_style"]).get_style_defs(dark_sel)
+        light_css = HtmlFormatter(style=self.config["light_style"]).get_style_defs(
+            light_sel
+        )
+        dark_css = HtmlFormatter(style=self.config["dark_style"]).get_style_defs(
+            dark_sel
+        )
 
         out_path.write_text(light_css + "\n\n" + dark_css + "\n", encoding="utf-8")
-
-        extra_css = config.setdefault("extra_css", [])
-        if self.config["css_path"] not in extra_css:
-            extra_css.append(self.config["css_path"])
 
         return config


### PR DESCRIPTION
Code blocks had white stripes and the logo was missing (on a previous gh-deploy).
- [x] removed `use_pygments` from `markdown_extensions.pymdownx.highlight` and `hhat-heather-pygments` from `plugins` to fix the white stripes
- [x] include the logo properly (check changes)