### PR TITLE
feat: add quantum device config support

### DIFF
--- a/python/src/hhat_lang/core/config/quantum_device.py
+++ b/python/src/hhat_lang/core/config/quantum_device.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hhat_lang.core.config.utils import read_file
+
+DEFAULT_QUANTUM_CONFIG_FILE = "quantum_config.toml"
+
+
+@dataclass(frozen=True)
+class QuantumDeviceSpecs:
+    max_n_qubits: int
+    qubit_topology: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> QuantumDeviceSpecs:
+        return cls(
+            max_n_qubits=int(data["max_n_qubits"]),
+            qubit_topology=dict(data.get("qubit_topology", {})),
+        )
+
+    def validate(self) -> None:
+        if self.max_n_qubits < 1:
+            raise ValueError("quantum device max_n_qubits must be greater than zero.")
+
+    def serialize(self) -> dict[str, Any]:
+        return {
+            "max_n_qubits": self.max_n_qubits,
+            "qubit_topology": self.qubit_topology,
+        }
+
+
+@dataclass(frozen=True)
+class QuantumLowLevelLanguage:
+    name: str
+    package_name: str
+    package_version: str
+    file_extension: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "file_extension", self.file_extension.lstrip("."))
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> QuantumLowLevelLanguage:
+        return cls(
+            name=str(data["name"]),
+            package_name=str(data["package_name"]),
+            package_version=str(data["package_version"]),
+            file_extension=str(data["file_extension"]),
+        )
+
+    def validate(self) -> None:
+        if not self.name:
+            raise ValueError("quantum low-level language name must be defined.")
+        if not self.package_name:
+            raise ValueError("quantum low-level language package_name must be defined.")
+        if not self.file_extension:
+            raise ValueError("quantum low-level language file_extension must be defined.")
+
+    def serialize(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "package_name": self.package_name,
+            "package_version": self.package_version,
+            "file_extension": self.file_extension,
+        }
+
+
+@dataclass(frozen=True)
+class QuantumDevice:
+    name: str
+    is_active: bool
+    vendor: str
+    device_kind: str
+    device_platform: str
+    computation_paradigm: tuple[str, ...]
+    specs: QuantumDeviceSpecs
+    qll: QuantumLowLevelLanguage
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> QuantumDevice:
+        return cls(
+            name=str(data["name"]),
+            is_active=_read_bool(data["is_active"], field_name="is_active"),
+            vendor=str(data["vendor"]),
+            device_kind=str(data["device_kind"]),
+            device_platform=str(data["device_platform"]),
+            computation_paradigm=_read_string_tuple(data["computation_paradigm"]),
+            specs=QuantumDeviceSpecs.from_mapping(data["specs"]),
+            qll=QuantumLowLevelLanguage.from_mapping(data["qll"]),
+            extra=dict(data.get("extra", {})),
+        )
+
+    def validate(self) -> None:
+        if not self.name:
+            raise ValueError("quantum device name must be defined.")
+        if not self.vendor:
+            raise ValueError(f"quantum device {self.name!r} must define a vendor.")
+        if self.device_kind not in {"device", "simulator"}:
+            raise ValueError(f"quantum device {self.name!r} kind must be 'device' or 'simulator'.")
+        if not self.device_platform:
+            raise ValueError(f"quantum device {self.name!r} must define a platform.")
+        if not self.computation_paradigm:
+            raise ValueError(
+                f"quantum device {self.name!r} must define at least one computation paradigm."
+            )
+        self.specs.validate()
+        self.qll.validate()
+
+    def serialize(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "is_active": self.is_active,
+            "vendor": self.vendor,
+            "device_kind": self.device_kind,
+            "device_platform": self.device_platform,
+            "computation_paradigm": list(self.computation_paradigm),
+            "specs": self.specs.serialize(),
+            "qll": self.qll.serialize(),
+            "extra": self.extra,
+        }
+
+
+@dataclass(frozen=True)
+class QuantumDeviceConfig:
+    title: str
+    version: str
+    devices: tuple[QuantumDevice, ...]
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> QuantumDeviceConfig:
+        return cls(
+            title=str(data["title"]),
+            version=str(data["version"]),
+            devices=tuple(QuantumDevice.from_mapping(device) for device in data["devices"]),
+        )
+
+    @property
+    def active_devices(self) -> tuple[QuantumDevice, ...]:
+        return tuple(device for device in self.devices if device.is_active)
+
+    def validate(self) -> None:
+        if not self.title:
+            raise ValueError("quantum device configuration title must be defined.")
+        if not self.version:
+            raise ValueError("quantum device configuration version must be defined.")
+        if not self.devices:
+            raise ValueError("quantum device configuration must contain at least one device.")
+        for device in self.devices:
+            device.validate()
+        if not self.active_devices:
+            raise ValueError(
+                "quantum device configuration must contain at least one active device."
+            )
+
+    def serialize(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "version": self.version,
+            "devices": [device.serialize() for device in self.devices],
+        }
+
+
+def load_quantum_device_config(file: Path | str) -> QuantumDeviceConfig:
+    config = QuantumDeviceConfig.from_mapping(read_file(Path(file)))
+    config.validate()
+    return config
+
+
+def write_quantum_device_config(config: QuantumDeviceConfig, file: Path | str) -> None:
+    config.validate()
+    path = Path(file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dump_quantum_device_config(config), encoding="utf-8")
+
+
+def dump_quantum_device_config(config: QuantumDeviceConfig) -> str:
+    config.validate()
+    lines = [
+        f"title = {_format_toml_value(config.title)}",
+        f"version = {_format_toml_value(config.version)}",
+    ]
+
+    for device in config.devices:
+        lines.extend(
+            (
+                "",
+                "[[devices]]",
+                f"name = {_format_toml_value(device.name)}",
+                f"is_active = {_format_toml_value(device.is_active)}",
+                f"vendor = {_format_toml_value(device.vendor)}",
+                f"device_kind = {_format_toml_value(device.device_kind)}",
+                f"device_platform = {_format_toml_value(device.device_platform)}",
+                f"computation_paradigm = {_format_toml_value(list(device.computation_paradigm))}",
+                "",
+                "[devices.specs]",
+                f"max_n_qubits = {_format_toml_value(device.specs.max_n_qubits)}",
+                f"qubit_topology = {_format_toml_value(device.specs.qubit_topology)}",
+                "",
+                "[devices.qll]",
+                f"name = {_format_toml_value(device.qll.name)}",
+                f"package_name = {_format_toml_value(device.qll.package_name)}",
+                f"package_version = {_format_toml_value(device.qll.package_version)}",
+                f"file_extension = {_format_toml_value(device.qll.file_extension)}",
+            )
+        )
+
+        if device.extra:
+            lines.extend(
+                (
+                    "",
+                    "[devices.extra]",
+                    *(
+                        f"{key} = {_format_toml_value(value)}"
+                        for key, value in sorted(device.extra.items())
+                    ),
+                )
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def _format_toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return repr(value)
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, list | tuple):
+        return "[" + ", ".join(_format_toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        items = (
+            f"{_format_toml_key(str(key))} = {_format_toml_value(item)}"
+            for key, item in sorted(value.items())
+        )
+        return "{ " + ", ".join(items) + " }"
+    if value is None:
+        raise TypeError("TOML does not support null values.")
+
+    raise TypeError(f"cannot serialize value {value!r} as TOML.")
+
+
+def _format_toml_key(key: str) -> str:
+    if key.replace("_", "").replace("-", "").isalnum():
+        return key
+    return repr(key)
+
+
+def _read_bool(value: Any, *, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{field_name} must be a boolean value.")
+    return value
+
+
+def _read_string_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    return tuple(str(item) for item in value)

--- a/python/src/hhat_lang/core/config/utils.py
+++ b/python/src/hhat_lang/core/config/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import wraps
 from pathlib import Path
-from typing import Callable, Any
+from typing import Any, Callable
 
 conversion_types: dict[str, Callable[[Path], dict | Any]] = dict()
 """
@@ -33,7 +33,10 @@ def read_json(file: Path) -> dict:
 
 @insert_reader("toml")
 def read_toml(file: Path) -> Any:
-    raise NotImplementedError("reading TOML config files for H-hat not implemented yet.")
+    import tomllib
+
+    with open(file, "rb") as fp:
+        return tomllib.load(fp)
 
 
 @insert_reader("yaml")

--- a/python/tests/core/test_quantum_device_config.py
+++ b/python/tests/core/test_quantum_device_config.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hhat_lang.core.config.quantum_device import (
+    QuantumDevice,
+    QuantumDeviceConfig,
+    QuantumDeviceSpecs,
+    QuantumLowLevelLanguage,
+    dump_quantum_device_config,
+    load_quantum_device_config,
+    write_quantum_device_config,
+)
+from hhat_lang.core.config.utils import read_file
+
+
+def _dummy_config() -> QuantumDeviceConfig:
+    return QuantumDeviceConfig(
+        title="H-hat Compiler Quantum Device Configuration",
+        version="0.1.0",
+        devices=(
+            QuantumDevice(
+                name="AerSimulator",
+                is_active=True,
+                vendor="IBM",
+                device_kind="simulator",
+                device_platform="superconducting",
+                computation_paradigm=("gate",),
+                specs=QuantumDeviceSpecs(
+                    max_n_qubits=32,
+                    qubit_topology={"kind": "all-to-all"},
+                ),
+                qll=QuantumLowLevelLanguage(
+                    name="openqasm",
+                    package_name="qiskit",
+                    package_version="1.0",
+                    file_extension="qasm",
+                ),
+                extra={"basis_gates": ["h", "cx", "rz"]},
+            ),
+            QuantumDevice(
+                name="Tuna-17",
+                is_active=False,
+                vendor="QuTech",
+                device_kind="device",
+                device_platform="superconducting",
+                computation_paradigm=("gate",),
+                specs=QuantumDeviceSpecs(
+                    max_n_qubits=17,
+                    qubit_topology={"kind": "line", "size": 17},
+                ),
+                qll=QuantumLowLevelLanguage(
+                    name="netqasm",
+                    package_name="netqasm",
+                    package_version="0.15",
+                    file_extension=".nqasm",
+                ),
+            ),
+        ),
+    )
+
+
+def test_write_and_load_quantum_device_config(tmp_path: Path) -> None:
+    config_file = tmp_path / "quantum_config.toml"
+
+    write_quantum_device_config(_dummy_config(), config_file)
+    config = load_quantum_device_config(config_file)
+
+    assert config.title == "H-hat Compiler Quantum Device Configuration"
+    assert [device.name for device in config.devices] == ["AerSimulator", "Tuna-17"]
+    assert [device.name for device in config.active_devices] == ["AerSimulator"]
+    assert config.devices[0].specs.qubit_topology == {"kind": "all-to-all"}
+    assert config.devices[1].qll.file_extension == "nqasm"
+
+
+def test_dump_quantum_device_config_is_readable_toml(tmp_path: Path) -> None:
+    config_file = tmp_path / "quantum_config.toml"
+    config_file.write_text(dump_quantum_device_config(_dummy_config()), encoding="utf-8")
+
+    data = read_file(config_file)
+
+    assert data["title"] == "H-hat Compiler Quantum Device Configuration"
+    assert data["devices"][0]["qll"]["name"] == "openqasm"
+    assert data["devices"][0]["extra"]["basis_gates"] == ["h", "cx", "rz"]
+
+
+def test_quantum_device_config_requires_active_device() -> None:
+    inactive_device = QuantumDevice(
+        name="InactiveSimulator",
+        is_active=False,
+        vendor="Test",
+        device_kind="simulator",
+        device_platform="superconducting",
+        computation_paradigm=("gate",),
+        specs=QuantumDeviceSpecs(max_n_qubits=1),
+        qll=QuantumLowLevelLanguage(
+            name="openqasm",
+            package_name="qiskit",
+            package_version="1.0",
+            file_extension="qasm",
+        ),
+    )
+    config = QuantumDeviceConfig(
+        title="H-hat Compiler Quantum Device Configuration",
+        version="0.1.0",
+        devices=(inactive_device,),
+    )
+
+    with pytest.raises(ValueError, match="at least one active device"):
+        config.validate()
+
+
+def test_quantum_device_config_validates_device_kind() -> None:
+    invalid_device = QuantumDevice(
+        name="InvalidDevice",
+        is_active=True,
+        vendor="Test",
+        device_kind="processor",
+        device_platform="superconducting",
+        computation_paradigm=("gate",),
+        specs=QuantumDeviceSpecs(max_n_qubits=1),
+        qll=QuantumLowLevelLanguage(
+            name="openqasm",
+            package_name="qiskit",
+            package_version="1.0",
+            file_extension="qasm",
+        ),
+    )
+    config = QuantumDeviceConfig(
+        title="H-hat Compiler Quantum Device Configuration",
+        version="0.1.0",
+        devices=(invalid_device,),
+    )
+
+    with pytest.raises(ValueError, match="'device' or 'simulator'"):
+        config.validate()
+
+
+def test_quantum_device_from_mapping_keeps_single_paradigm_string_intact() -> None:
+    device = QuantumDevice.from_mapping(
+        {
+            "name": "AerSimulator",
+            "is_active": True,
+            "vendor": "IBM",
+            "device_kind": "simulator",
+            "device_platform": "superconducting",
+            "computation_paradigm": "gate",
+            "specs": {"max_n_qubits": 32},
+            "qll": {
+                "name": "openqasm",
+                "package_name": "qiskit",
+                "package_version": "1.0",
+                "file_extension": "qasm",
+            },
+        }
+    )
+
+    assert device.computation_paradigm == ("gate",)
+
+
+def test_quantum_device_from_mapping_rejects_non_boolean_active_flag() -> None:
+    with pytest.raises(TypeError, match="is_active must be a boolean"):
+        QuantumDevice.from_mapping(
+            {
+                "name": "AerSimulator",
+                "is_active": "false",
+                "vendor": "IBM",
+                "device_kind": "simulator",
+                "device_platform": "superconducting",
+                "computation_paradigm": ["gate"],
+                "specs": {"max_n_qubits": 32},
+                "qll": {
+                    "name": "openqasm",
+                    "package_name": "qiskit",
+                    "package_version": "1.0",
+                    "file_extension": "qasm",
+                },
+            }
+        )


### PR DESCRIPTION
## Summary

- Add a dedicated `QuantumDeviceConfig` model for `quantum_config.toml` files.
- Support loading, dumping, and writing quantum device entries with device specs, QLL metadata, active-device flags, and optional extra vendor data.
- Implement TOML config reading via the standard-library `tomllib`.
- Add tests for TOML round-trip behavior, active-device validation, device-kind validation, extension normalization, and robust mapping parsing.

Closes #63

## unitaryHACK 2026

Registered for the event as `huhaha120`.

## Tests

```bash
PYTHONPATH=python/src uv run --python 3.11 --with pytest python -m pytest python/tests/core/test_quantum_device_config.py -q
PYTHONPATH=python/src uv run --python 3.11 --with ruff ruff check python/src/hhat_lang/core/config/quantum_device.py python/src/hhat_lang/core/config/utils.py python/tests/core/test_quantum_device_config.py
PYTHONPATH=python/src uv run --python 3.11 --with ruff ruff format --check python/src/hhat_lang/core/config/quantum_device.py python/src/hhat_lang/core/config/utils.py python/tests/core/test_quantum_device_config.py
git diff --check
```

## Notes

- I also tried the wider `python/tests/core` suite. It currently fails during collection on existing circular import / builtin type initialization issues unrelated to this change, so the PR includes focused coverage for the new config module.

<!-- Please fill in the disclosure below: -->

### Generative AI/LLM disclosure

Code and Logic Architecture/Design:

- [ ] The code and logic architecture/design contain no generative AI/LLM
- [ ] The code and logic architecture/design are partially performed by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [x] The code and logic architecture/design are fully performed by generative AI/LLM


Code content:

- [ ] The code contains no generative AI/LLM work
- [ ] The code is partially written by generative AI/L
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [x] The code is fully written by generative AI/LLM


Code review:

- [ ] The code review contains no generative AI/LLM
- [ ] The code review is partially done by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [x] The code review is fully done by generative AI/LLM


Code tests:

- [ ] The code tests contain no generative AI/LLM
- [ ] The code tests are partially written by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [x] The code tests are fully written by generative AI/LLM
