### PR TITLE
feat: sync project docs from hat files

### DIFF
--- a/python/src/hhat_lang/toolchain/cli/cli.py
+++ b/python/src/hhat_lang/toolchain/cli/cli.py
@@ -10,12 +10,13 @@ from rich.console import Console
 from rich.panel import Panel
 
 from hhat_lang.toolchain.project.new import (
+    create_new_const_file,
     create_new_fn_file,
     create_new_project,
     create_new_type_file,
-    create_new_const_file,
 )
 from hhat_lang.toolchain.project.run import run_project
+from hhat_lang.toolchain.project.update import update_project
 from hhat_lang.toolchain.project.utils import get_proj_dir
 
 app = typer.Typer(
@@ -70,6 +71,7 @@ def help(command: Optional[str] = typer.Argument(None, help="Command to get help
                 "[bold]Available commands:[/bold]\n"
                 "  [bold]new[/bold]     Create a new project, file, or type file\n"
                 "  [bold]run[/bold]     Run the current H-hat project\n"
+                "  [bold]update[/bold]  Synchronize docs with project code\n"
                 "  [bold]help[/bold]    Show this help message\n\n"
                 "Use [bold]hat help <command>[/bold] for detailed information about a command.",
                 title="hat - Command Line Interface",
@@ -263,6 +265,41 @@ def run() -> None:
             Panel(
                 f"An error occurred while running the project: {str(e)}\n\n"
                 "Please check your code for errors.",
+                title="⚠ Error",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(1)
+
+
+@app.command()
+def update() -> None:
+    """
+    Synchronize project documentation with current H-hat code files.
+
+    This command must be executed from within a H-hat project directory.
+
+    Example:
+        hat update
+    """
+    try:
+        project_dir = get_proj_dir()
+        summary = update_project(project_dir)
+        console.print(
+            Panel(
+                "Documentation synchronized successfully!\n\n"
+                f"Created docs: {summary.created_docs}\n"
+                f"Updated docs: {summary.updated_docs}\n"
+                f"Orphaned docs: {summary.orphaned_docs}",
+                title="✓ Success",
+                border_style="green",
+            )
+        )
+    except Exception as e:
+        console.print(
+            Panel(
+                f"An error occurred while updating documentation: {str(e)}\n\n"
+                "Please make sure you're inside a valid H-hat project directory.",
                 title="⚠ Error",
                 border_style="red",
             )

--- a/python/src/hhat_lang/toolchain/project/__init__.py
+++ b/python/src/hhat_lang/toolchain/project/__init__.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 # base folder names
-SOURCE_FOLDER_NAME = "src"
-TYPES_FOLDER_NAME = "hat_types"
-IMPORTS_FOLDER_NAME = ".hat_imports"  # must be a hidden folder
-DOCS_FOLDER_NAME = "docs"
-TESTS_FOLDER_NAME = "tests"  # future use
-PROOFS_FOLDER_NAME = "proofs"  # future use
+SOURCE_FOLDER_NAME = Path("src")
+TYPES_FOLDER_NAME = Path("hat_types")
+IMPORTS_FOLDER_NAME = Path(".hat_imports")  # must be a hidden folder
+DOCS_FOLDER_NAME = Path("docs")
+TESTS_FOLDER_NAME = Path("tests")  # future use
+PROOFS_FOLDER_NAME = Path("proofs")  # future use
 
 # files
 MAIN_FILE_NAME = "main.hat"
 
-MAIN_DOC_FILE_NAME = f"{MAIN_FILE_NAME}.md"
+MAIN_DOC_FILE_NAME = f"{Path(MAIN_FILE_NAME).stem}.md"
 
 # paths
-MAIN_PATH = SOURCE_FOLDER_NAME / MAIN_DOC_FILE_NAME
-IMPORTS_PATH = f"{SOURCE_FOLDER_NAME}/{IMPORTS_FOLDER_NAME}"
-SOURCE_TYPES_PATH = f"{SOURCE_FOLDER_NAME}/{TYPES_FOLDER_NAME}"
-DOCS_TYPES_PATH = f"{DOCS_FOLDER_NAME}/{TYPES_FOLDER_NAME}"
+MAIN_PATH = SOURCE_FOLDER_NAME / MAIN_FILE_NAME
+IMPORTS_PATH = SOURCE_FOLDER_NAME / IMPORTS_FOLDER_NAME
+SOURCE_TYPES_PATH = SOURCE_FOLDER_NAME / TYPES_FOLDER_NAME
+DOCS_TYPES_PATH = DOCS_FOLDER_NAME / TYPES_FOLDER_NAME

--- a/python/src/hhat_lang/toolchain/project/new.py
+++ b/python/src/hhat_lang/toolchain/project/new.py
@@ -9,13 +9,13 @@ from typing import Any
 from hhat_lang.toolchain.project import (
     DOCS_FOLDER_NAME,
     DOCS_TYPES_PATH,
+    IMPORTS_FOLDER_NAME,
+    IMPORTS_PATH,
     MAIN_DOC_FILE_NAME,
     MAIN_FILE_NAME,
     SOURCE_FOLDER_NAME,
     SOURCE_TYPES_PATH,
-    IMPORTS_FOLDER_NAME,
     TESTS_FOLDER_NAME,
-    IMPORTS_PATH,
 )
 from hhat_lang.toolchain.project.utils import str_to_path
 
@@ -58,7 +58,7 @@ def _create_template_files(project_name: Path) -> Any:
         f.write("main {\n\n}\n\n")
 
     with open(project_name / DOCS_FOLDER_NAME / MAIN_DOC_FILE_NAME, "w") as f:
-        f.write(f"# {project_name.name}\n\n")
+        f.write(f"# {project_name.name}\n")
 
 
 ###################
@@ -68,7 +68,7 @@ def _create_template_files(project_name: Path) -> Any:
 
 def create_new_fn_file(project_root: Path, file_name: str | Path) -> Path:
     file_name = str(file_name) + ".hat"
-    doc_file = file_name + ".md"
+    doc_file = Path(file_name).with_suffix(".md")
     file_path: Path = project_root / SOURCE_FOLDER_NAME / file_name
 
     if file_path.is_file():
@@ -89,7 +89,7 @@ def create_new_fn_file(project_root: Path, file_name: str | Path) -> Path:
 
 def create_new_type_file(project_path: Path, file_name: str | Path) -> Path:
     file_name = str(file_name) + ".hat"
-    doc_file = file_name + ".md"
+    doc_file = Path(file_name).with_suffix(".md")
     file_path: Path = project_path / SOURCE_TYPES_PATH / file_name
 
     if file_path.is_file():
@@ -110,7 +110,7 @@ def create_new_type_file(project_path: Path, file_name: str | Path) -> Path:
 
 def create_new_const_file(project_path: Path, file_name: str | Path) -> Path:
     file_name = str(file_name) + ".hat"
-    doc_file = file_name + ".md"
+    doc_file = Path(file_name).with_suffix(".md")
     file_path: Path = project_path / SOURCE_FOLDER_NAME / file_name
 
     if file_path.is_file():

--- a/python/src/hhat_lang/toolchain/project/update.py
+++ b/python/src/hhat_lang/toolchain/project/update.py
@@ -5,13 +5,401 @@ the existing files.
 
 from __future__ import annotations
 
-import os
+import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
+from hhat_lang.toolchain.project import DOCS_FOLDER_NAME, SOURCE_FOLDER_NAME
 from hhat_lang.toolchain.project.utils import str_to_path
 
 
-def update_project(project_name: str | Path) -> Any:
-    project_name = str_to_path(project_name)
-    # TODO: implement it
+@dataclass(frozen=True)
+class SignatureField:
+    """A named type-bearing entry in a generated documentation signature."""
+
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class Signature:
+    """Structured top-level H-hat declaration used to render documentation."""
+
+    name: str
+    kind: str
+    paradigm: str
+    type: str = ""
+    arguments: tuple[SignatureField, ...] = ()
+    members: tuple[SignatureField, ...] = ()
+    variants: tuple[SignatureField, ...] = ()
+
+
+@dataclass(frozen=True)
+class UpdateSummary:
+    """Summary of documentation changes made by ``hat update``."""
+
+    created_docs: int
+    updated_docs: int
+    orphaned_docs: int
+
+
+def update_project(project_name: str | Path) -> UpdateSummary:
+    """Synchronize a project's ``docs/`` tree with top-level ``.hat`` files.
+
+    The update step mirrors every ``src/**/*.hat`` file to ``docs/**/*.md``,
+    renders function and type signatures, preserves existing free-form
+    documentation sections, and renames documentation files without a source
+    counterpart to ``orphan.<name>.md``.
+    """
+
+    project_root = str_to_path(project_name)
+    src_root = project_root / SOURCE_FOLDER_NAME
+    docs_root = project_root / DOCS_FOLDER_NAME
+
+    if not src_root.is_dir():
+        raise ValueError(f"Source folder not found: {src_root}")
+
+    docs_root.mkdir(parents=True, exist_ok=True)
+
+    expected_docs: set[Path] = set()
+    created_docs = 0
+    updated_docs = 0
+
+    for code_path in _iter_code_files(src_root):
+        relative_code_path = code_path.relative_to(src_root)
+        doc_path = docs_root / relative_code_path.with_suffix(".md")
+        legacy_doc_path = docs_root / Path(str(relative_code_path) + ".md")
+        existing_doc_path = _first_existing_path(doc_path, legacy_doc_path)
+        existing_content = existing_doc_path.read_text() if existing_doc_path else ""
+
+        signatures = parse_code_signatures(code_path.read_text())
+        new_content = render_doc_content(relative_code_path, signatures, existing_content)
+
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        expected_docs.add(doc_path.resolve())
+
+        if not doc_path.exists():
+            created_docs += 1
+            doc_path.write_text(new_content)
+        elif doc_path.read_text() != new_content:
+            updated_docs += 1
+            doc_path.write_text(new_content)
+
+    orphaned_docs = _rename_orphan_docs(docs_root, expected_docs)
+
+    return UpdateSummary(
+        created_docs=created_docs,
+        updated_docs=updated_docs,
+        orphaned_docs=orphaned_docs,
+    )
+
+
+def parse_code_signatures(code: str) -> tuple[Signature, ...]:
+    """Extract supported top-level function and type signatures from H-hat code."""
+
+    clean_code = _strip_comments(code)
+    signatures = [*_parse_function_signatures(clean_code), *_parse_type_signatures(clean_code)]
+    return tuple(sorted(signatures, key=lambda item: (item.name, item.kind, item.type)))
+
+
+def render_doc_content(
+    relative_code_path: Path,
+    signatures: tuple[Signature, ...],
+    existing_content: str = "",
+) -> str:
+    """Render a mirrored Markdown documentation file for a source file."""
+
+    existing_docs = _extract_existing_documentation(existing_content)
+    header = _extract_existing_header(existing_content)
+    if not header.strip():
+        header = f"# {relative_code_path.with_suffix('').as_posix()}\n"
+
+    sections = [header.rstrip(), ""]
+    for signature in signatures:
+        documentation = existing_docs.get(signature.name, "").strip()
+        sections.append(_render_signature_section(signature, documentation))
+
+    return "\n\n".join(section for section in sections if section != "").rstrip() + "\n"
+
+
+def _iter_code_files(src_root: Path) -> tuple[Path, ...]:
+    return tuple(
+        sorted(
+            path
+            for path in src_root.rglob("*.hat")
+            if ".hat_imports" not in path.relative_to(src_root).parts
+        )
+    )
+
+
+def _first_existing_path(*paths: Path) -> Path | None:
+    return next((path for path in paths if path.exists()), None)
+
+
+def _strip_comments(code: str) -> str:
+    code = re.sub(r"/\*.*?\*/", "", code, flags=re.DOTALL)
+    return re.sub(r"//.*", "", code)
+
+
+def _parse_function_signatures(code: str) -> tuple[Signature, ...]:
+    function_pattern = re.compile(
+        r"(?<![\w-])fn\s+"
+        r"(?P<name>@?[A-Za-z_][A-Za-z0-9_-]*)\s*"
+        r"\((?P<args>[^)]*)\)\s*"
+        r"(?P<type>[^\s{]+)?\s*\{",
+        re.MULTILINE,
+    )
+
+    signatures = []
+    for match in function_pattern.finditer(code):
+        name = match.group("name")
+        return_type = (match.group("type") or "null").strip()
+        signatures.append(
+            Signature(
+                name=name,
+                type=return_type,
+                kind="function",
+                paradigm=_paradigm(name, return_type),
+                arguments=_parse_typed_fields(match.group("args")),
+            )
+        )
+
+    return tuple(signatures)
+
+
+def _parse_type_signatures(code: str) -> tuple[Signature, ...]:
+    signatures: list[Signature] = []
+    pattern = re.compile(r"(?<![\w-])type\s+(?P<name>@?[A-Za-z_][A-Za-z0-9_-]*)")
+    index = 0
+
+    while True:
+        match = pattern.search(code, index)
+        if match is None:
+            break
+
+        name = match.group("name")
+        cursor = _skip_spaces(code, match.end())
+        if cursor < len(code) and code[cursor] == ":":
+            type_name, index = _read_type_alias(code, cursor + 1)
+            signatures.append(
+                Signature(
+                    name=name,
+                    type=type_name,
+                    kind="primitive",
+                    paradigm=_paradigm(name, type_name),
+                )
+            )
+        elif cursor < len(code) and code[cursor] == "{":
+            body, index = _read_braced_block(code, cursor)
+            signatures.append(_signature_from_type_body(name, body))
+        else:
+            index = match.end()
+
+    return tuple(signatures)
+
+
+def _skip_spaces(text: str, index: int) -> int:
+    while index < len(text) and text[index].isspace():
+        index += 1
+    return index
+
+
+def _read_type_alias(code: str, index: int) -> tuple[str, int]:
+    index = _skip_spaces(code, index)
+    start = index
+    while index < len(code) and not code[index].isspace() and code[index] not in "{}":
+        index += 1
+    return code[start:index].strip(), index
+
+
+def _read_braced_block(code: str, index: int) -> tuple[str, int]:
+    depth = 0
+    start = index + 1
+
+    for cursor in range(index, len(code)):
+        if code[cursor] == "{":
+            depth += 1
+        elif code[cursor] == "}":
+            depth -= 1
+            if depth == 0:
+                return code[start:cursor], cursor + 1
+
+    raise ValueError("Unclosed type body")
+
+
+def _signature_from_type_body(name: str, body: str) -> Signature:
+    items = _parse_body_items(body)
+    if items and all(":" in item and "{" not in item for item in items):
+        members = tuple(
+            SignatureField(field_name, field_type)
+            for field_name, field_type in (_split_typed_item(item) for item in items)
+        )
+        return Signature(
+            name=name,
+            kind="struct",
+            paradigm=_paradigm(name, *(field.type for field in members)),
+            members=members,
+        )
+
+    variants = tuple(SignatureField(_variant_name(item), _variant_type(item)) for item in items)
+    return Signature(
+        name=name,
+        kind="enum",
+        paradigm=_paradigm(name),
+        variants=variants,
+    )
+
+
+def _parse_body_items(body: str) -> tuple[str, ...]:
+    items: list[str] = []
+    cursor = 0
+
+    while cursor < len(body):
+        cursor = _skip_spaces(body, cursor)
+        if cursor >= len(body):
+            break
+
+        start = cursor
+        while cursor < len(body) and not body[cursor].isspace() and body[cursor] != "{":
+            cursor += 1
+
+        head = body[start:cursor].strip()
+        cursor = _skip_spaces(body, cursor)
+        if cursor < len(body) and body[cursor] == "{":
+            braced_body, cursor = _read_braced_block(body, cursor)
+            items.append(f"{head} {{{braced_body.strip()}}}")
+        elif head:
+            items.append(head)
+
+    return tuple(items)
+
+
+def _parse_typed_fields(text: str) -> tuple[SignatureField, ...]:
+    fields = []
+    field_pattern = re.compile(r"(@?[A-Za-z_][A-Za-z0-9_-]*)\s*:\s*([@\[\]A-Za-z0-9_-]+)")
+    for name, field_type in field_pattern.findall(text):
+        fields.append(SignatureField(name=name, type=field_type))
+    return tuple(fields)
+
+
+def _split_typed_item(item: str) -> tuple[str, str]:
+    name, field_type = item.split(":", maxsplit=1)
+    return name.strip(), field_type.strip()
+
+
+def _variant_name(item: str) -> str:
+    return item.split("{", maxsplit=1)[0].strip()
+
+
+def _variant_type(item: str) -> str:
+    return "Tagged" if "{" in item else "Named"
+
+
+def _paradigm(*values: str) -> str:
+    return (
+        "quantum"
+        if any(value.strip().startswith("@") for value in values if value)
+        else "classical"
+    )
+
+
+def _extract_existing_header(content: str) -> str:
+    match = re.search(r"^##\s+", content, flags=re.MULTILINE)
+    if match is None:
+        return content.strip()
+    return content[: match.start()].strip()
+
+
+def _extract_existing_documentation(content: str) -> dict[str, str]:
+    docs: dict[str, str] = {}
+    section_pattern = re.compile(r"^##\s+(?P<name>.+?)\s*$", re.MULTILINE)
+    matches = list(section_pattern.finditer(content))
+
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(content)
+        section = content[start:end]
+        doc_match = re.search(r"^###\s+Documentation\s*$", section, flags=re.MULTILINE)
+        if doc_match:
+            docs[match.group("name").strip()] = section[doc_match.end() :].strip()
+
+    return docs
+
+
+def _render_signature_section(signature: Signature, documentation: str) -> str:
+    parts = [
+        f"## {signature.name}",
+        "",
+        "### Signature",
+        "",
+        f"- Name: {signature.name}",
+        *_render_signature_details(signature),
+        "",
+        "### Documentation",
+        "",
+        documentation,
+    ]
+    return "\n".join(parts).rstrip()
+
+
+def _render_signature_details(signature: Signature) -> list[str]:
+    details = [
+        f"- Kind: {signature.kind}",
+        f"- Paradigm: {signature.paradigm}",
+    ]
+
+    if signature.kind == "function":
+        details.insert(0, f"- Type: {signature.type}")
+        details.extend(_render_field_table("Arguments", "Argument", signature.arguments))
+    elif signature.kind == "struct":
+        details.extend(_render_field_table("Members/Fields", "Member/Field", signature.members))
+    elif signature.kind == "enum":
+        details.extend(_render_field_table("Variants", "Variant", signature.variants))
+    elif signature.type:
+        details.insert(0, f"- Type: {signature.type}")
+
+    return details
+
+
+def _render_field_table(
+    title: str,
+    first_column: str,
+    fields: tuple[SignatureField, ...],
+) -> list[str]:
+    if not fields:
+        return [f"- {title}: None"]
+
+    lines = [
+        f"- {title}:",
+        "",
+        f"  | {first_column} | Type | Paradigm |",
+        "  | :--- | :--- | :--- |",
+    ]
+    lines.extend(
+        f"  | {field.name} | {field.type} | {_paradigm(field.name, field.type)} |"
+        for field in fields
+    )
+    return lines
+
+
+def _rename_orphan_docs(docs_root: Path, expected_docs: set[Path]) -> int:
+    orphaned_docs = 0
+
+    for doc_path in sorted(docs_root.rglob("*.md")):
+        if doc_path.resolve() in expected_docs or doc_path.name.startswith("orphan."):
+            continue
+
+        orphan_path = _next_orphan_path(doc_path)
+        doc_path.rename(orphan_path)
+        orphaned_docs += 1
+
+    return orphaned_docs
+
+
+def _next_orphan_path(doc_path: Path) -> Path:
+    candidate = doc_path.with_name(f"orphan.{doc_path.name}")
+    counter = 1
+    while candidate.exists():
+        candidate = doc_path.with_name(f"orphan.{counter}.{doc_path.name}")
+        counter += 1
+    return candidate

--- a/python/tests/test_project_update.py
+++ b/python/tests/test_project_update.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from hhat_lang.toolchain.cli.cli import app
+from hhat_lang.toolchain.project.new import create_new_project
+from hhat_lang.toolchain.project.update import parse_code_signatures, update_project
+
+runner = CliRunner()
+
+
+def test_parse_code_signatures_from_functions_structs_and_enums() -> None:
+    code = """
+    fn some-fn (arg1:ty1 arg2:@ty2) fn-ty { fn-body }
+
+    type @some-struct-ty {
+        m1:ty1
+        @m2:@ty2
+    }
+
+    type some-enum-ty {
+      named1
+      tagged1 { m1:ty1 m2:ty2 }
+    }
+    """
+
+    signatures = {signature.name: signature for signature in parse_code_signatures(code)}
+
+    assert signatures["some-fn"].kind == "function"
+    assert signatures["some-fn"].type == "fn-ty"
+    assert [arg.name for arg in signatures["some-fn"].arguments] == ["arg1", "arg2"]
+
+    assert signatures["@some-struct-ty"].kind == "struct"
+    assert signatures["@some-struct-ty"].paradigm == "quantum"
+    assert [member.name for member in signatures["@some-struct-ty"].members] == ["m1", "@m2"]
+
+    assert signatures["some-enum-ty"].kind == "enum"
+    assert [variant.type for variant in signatures["some-enum-ty"].variants] == ["Named", "Tagged"]
+
+
+def test_update_project_mirrors_docs_and_preserves_manual_documentation(tmp_path: Path) -> None:
+    project = tmp_path / "sample"
+    create_new_project(project)
+
+    ops_file = project / "src" / "ops.hat"
+    ops_file.write_text("fn sum(a:i64 b:i64) i64 { ::add(a b) }\n")
+
+    type_file = project / "src" / "hat_types" / "shape.hat"
+    type_file.write_text(
+        """
+        type point { x:i32 y:i32 }
+        type status_t {
+            ON
+            DATA { value:u64 }
+        }
+        """
+    )
+
+    ops_doc = project / "docs" / "ops.md"
+    ops_doc.write_text(
+        """
+        # Previous title
+
+        ## sum
+
+        ### Signature
+
+        - old signature
+
+        ### Documentation
+
+        Keep this explanation.
+        """.strip()
+        + "\n"
+    )
+    stale_doc = project / "docs" / "stale.md"
+    stale_doc.write_text("# stale\n")
+
+    summary = update_project(project)
+
+    assert summary.created_docs == 1
+    assert summary.updated_docs == 1
+    assert summary.orphaned_docs == 1
+
+    updated_ops_doc = ops_doc.read_text()
+    assert "# Previous title" in updated_ops_doc
+    assert "- Type: i64" in updated_ops_doc
+    assert "| a | i64 | classical |" in updated_ops_doc
+    assert "Keep this explanation." in updated_ops_doc
+
+    updated_type_doc = (project / "docs" / "hat_types" / "shape.md").read_text()
+    assert "## point" in updated_type_doc
+    assert "| x | i32 | classical |" in updated_type_doc
+    assert "## status_t" in updated_type_doc
+    assert "| DATA | Tagged | classical |" in updated_type_doc
+
+    assert not stale_doc.exists()
+    assert (project / "docs" / "orphan.stale.md").exists()
+
+
+def test_update_cli_runs_from_project_directory(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "cli_project"
+    create_new_project(project)
+    (project / "src" / "math.hat").write_text("fn double(x:i64) i64 { ::add(x x) }\n")
+
+    monkeypatch.chdir(project)
+    result = runner.invoke(app, ["update"])
+
+    assert result.exit_code == 0
+    assert "Documentation synchronized successfully" in result.stdout
+    assert (project / "docs" / "math.md").exists()


### PR DESCRIPTION
## Summary

- Implements `hat update` for synchronizing project documentation with `.hat` source files.
- Mirrors `src/**/*.hat` to `docs/**/*.md`, preserving manual `### Documentation` content.
- Generates function, primitive type, struct, and enum signature sections.
- Renames documentation files without a source counterpart to `orphan.<name>.md`.
- Aligns new project/file doc creation with the `.hat` to `.md` mirror convention.

Closes #111.

## unitaryHACK 2026

Registered for the event as `huhaha120`.

## Validation

- `PYTHONPATH=python/src uv run --python 3.11 --with pytest --with typer --with rich python -m pytest python/tests/test_project_update.py python/tests/test_cli.py -q`
- `PYTHONPATH=python/src uv run --python 3.11 --with ruff ruff check python/src/hhat_lang/toolchain/project/update.py python/src/hhat_lang/toolchain/project/__init__.py python/src/hhat_lang/toolchain/project/new.py python/src/hhat_lang/toolchain/cli/cli.py python/tests/test_project_update.py python/tests/test_cli.py`
- `PYTHONPATH=python/src uv run --python 3.11 --with ruff ruff format --check python/src/hhat_lang/toolchain/project/update.py python/src/hhat_lang/toolchain/project/__init__.py python/src/hhat_lang/toolchain/project/new.py python/src/hhat_lang/toolchain/cli/cli.py python/tests/test_project_update.py`
- `PYTHONPATH=python/src uv run --python 3.11 python -m compileall -q python/src/hhat_lang/toolchain python/tests/test_project_update.py`
- `git diff --check`

<!-- Please fill in the disclosure below: -->

### Generative AI/LLM disclosure

Code and Logic Architecture/Design:

- [ ] The code and logic architecture/design contain no generative AI/LLM
- [ ] The code and logic architecture/design are partially performed by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [x] The code and logic architecture/design are fully performed by generative AI/LLM

Code content:

- [ ] The code contains no generative AI/LLM work
- [ ] The code is partially written by generative AI/L
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [x] The code is fully written by generative AI/LLM

Code review:

- [ ] The code review contains no generative AI/LLM
- [ ] The code review is partially done by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [x] The code review is fully done by generative AI/LLM

Code tests:

- [ ] The code tests contain no generative AI/LLM
- [ ] The code tests are partially written by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [x] The code tests are fully written by generative AI/LLM
