### PR TITLE
Add quantum device TOML config utilities

### DIFF
--- a/python/src/hhat_lang/core/config/quantum_device.py
+++ b/python/src/hhat_lang/core/config/quantum_device.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+DEFAULT_QUANTUM_CONFIG_FILENAME = "quantum_config.toml"
+DEFAULT_QUANTUM_CONFIG_TITLE = "H-hat Compiler Quantum Device Configuration"
+DEFAULT_QUANTUM_CONFIG_VERSION = "0.1.0"
+VALID_DEVICE_KINDS = frozenset({"simulator", "device"})
+
+
+@dataclass(frozen=True, slots=True)
+class QuantumDeviceSpecs:
+    max_n_qubits: int
+    qubit_topology: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> QuantumDeviceSpecs:
+        if "max_n_qubits" not in data:
+            raise ValueError("quantum device specs must define 'max_n_qubits'.")
+
+        return cls(
+            max_n_qubits=int(data["max_n_qubits"]),
+            qubit_topology=dict(data.get("qubit_topology", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "max_n_qubits": self.max_n_qubits,
+            "qubit_topology": dict(self.qubit_topology),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class QuantumLowLevelLanguage:
+    name: str
+    package_name: str
+    package_version: str = ""
+    file_extension: str = ""
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> QuantumLowLevelLanguage:
+        return cls(
+            name=str(data.get("name", "")),
+            package_name=str(data.get("package_name", "")),
+            package_version=str(data.get("package_version", "")),
+            file_extension=str(data.get("file_extension", "")),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "package_name": self.package_name,
+            "package_version": self.package_version,
+            "file_extension": self.file_extension,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class QuantumDevice:
+    name: str
+    is_active: bool
+    vendor: str
+    device_kind: str
+    device_platform: str
+    computation_paradigm: tuple[str, ...]
+    specs: QuantumDeviceSpecs
+    qll: QuantumLowLevelLanguage
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> QuantumDevice:
+        paradigms = data.get("computation_paradigm", ())
+        if isinstance(paradigms, str):
+            paradigms = (paradigms,)
+
+        return cls(
+            name=str(data.get("name", "")),
+            is_active=bool(data.get("is_active", False)),
+            vendor=str(data.get("vendor", "")),
+            device_kind=str(data.get("device_kind", "")),
+            device_platform=str(data.get("device_platform", "")),
+            computation_paradigm=tuple(str(item) for item in paradigms),
+            specs=QuantumDeviceSpecs.from_dict(data.get("specs", {})),
+            qll=QuantumLowLevelLanguage.from_dict(data.get("qll", {})),
+            extra=dict(data.get("extra", {})),
+        )
+
+    def validate(self) -> None:
+        if not self.name:
+            raise ValueError("quantum device must define 'name'.")
+        if self.device_kind not in VALID_DEVICE_KINDS:
+            raise ValueError(
+                f"quantum device '{self.name}' has unsupported device_kind '{self.device_kind}'."
+            )
+        if not self.computation_paradigm:
+            raise ValueError(
+                f"quantum device '{self.name}' must define at least one computation paradigm."
+            )
+        if self.specs.max_n_qubits < 1:
+            raise ValueError(
+                f"quantum device '{self.name}' must define a positive max_n_qubits value."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "is_active": self.is_active,
+            "vendor": self.vendor,
+            "device_kind": self.device_kind,
+            "device_platform": self.device_platform,
+            "computation_paradigm": list(self.computation_paradigm),
+            "specs": self.specs.to_dict(),
+            "qll": self.qll.to_dict(),
+            "extra": dict(self.extra),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class QuantumDeviceConfiguration:
+    devices: tuple[QuantumDevice, ...]
+    title: str = DEFAULT_QUANTUM_CONFIG_TITLE
+    version: str = DEFAULT_QUANTUM_CONFIG_VERSION
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> QuantumDeviceConfiguration:
+        devices = tuple(QuantumDevice.from_dict(item) for item in data.get("devices", ()))
+        config = cls(
+            title=str(data.get("title", DEFAULT_QUANTUM_CONFIG_TITLE)),
+            version=str(data.get("version", DEFAULT_QUANTUM_CONFIG_VERSION)),
+            devices=devices,
+        )
+        config.validate()
+        return config
+
+    @property
+    def active_devices(self) -> tuple[QuantumDevice, ...]:
+        return tuple(device for device in self.devices if device.is_active)
+
+    def validate(self) -> None:
+        if not self.devices:
+            raise ValueError("quantum device configuration must define at least one device.")
+
+        names: set[str] = set()
+        for device in self.devices:
+            device.validate()
+            if device.name in names:
+                raise ValueError(f"duplicate quantum device name '{device.name}'.")
+            names.add(device.name)
+
+        if not self.active_devices:
+            raise ValueError("quantum device configuration must define at least one active device.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "version": self.version,
+            "available": {
+                "active_devices": [device.name for device in self.active_devices],
+            },
+            "devices": [device.to_dict() for device in self.devices],
+        }
+
+
+def read_quantum_device_config(path: str | Path) -> QuantumDeviceConfiguration:
+    path = Path(path)
+    with path.open("rb") as fp:
+        return QuantumDeviceConfiguration.from_dict(tomllib.load(fp))
+
+
+def write_quantum_device_config(
+    config: QuantumDeviceConfiguration,
+    path: str | Path = DEFAULT_QUANTUM_CONFIG_FILENAME,
+) -> Path:
+    config.validate()
+    path = Path(path)
+    path.write_text(_serialize_quantum_config(config), encoding="utf-8")
+    return path
+
+
+def _serialize_quantum_config(config: QuantumDeviceConfiguration) -> str:
+    lines = [
+        f"title = {_format_toml_value(config.title)}",
+        f"version = {_format_toml_value(config.version)}",
+        "",
+        "[available]",
+        f"active_devices = {_format_toml_value([d.name for d in config.active_devices])}",
+    ]
+
+    for device in config.devices:
+        lines.extend(
+            [
+                "",
+                "[[devices]]",
+                f"name = {_format_toml_value(device.name)}",
+                f"is_active = {_format_toml_value(device.is_active)}",
+                f"vendor = {_format_toml_value(device.vendor)}",
+                f"device_kind = {_format_toml_value(device.device_kind)}",
+                f"device_platform = {_format_toml_value(device.device_platform)}",
+                f"computation_paradigm = {_format_toml_value(list(device.computation_paradigm))}",
+                "",
+                "[devices.specs]",
+                f"max_n_qubits = {_format_toml_value(device.specs.max_n_qubits)}",
+                f"qubit_topology = {_format_toml_value(dict(device.specs.qubit_topology))}",
+                "",
+                "[devices.qll]",
+                f"name = {_format_toml_value(device.qll.name)}",
+                f"package_name = {_format_toml_value(device.qll.package_name)}",
+                f"package_version = {_format_toml_value(device.qll.package_version)}",
+                f"file_extension = {_format_toml_value(device.qll.file_extension)}",
+                "",
+                "[devices.extra]",
+            ]
+        )
+
+        for key, value in dict(device.extra).items():
+            lines.append(f"{_format_toml_key(str(key))} = {_format_toml_value(value)}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _format_toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, Mapping):
+        return (
+            "{ "
+            + ", ".join(
+                f"{_format_toml_key(str(key))} = {_format_toml_value(val)}"
+                for key, val in value.items()
+            )
+            + " }"
+        )
+    if isinstance(value, list | tuple):
+        return "[" + ", ".join(_format_toml_value(item) for item in value) + "]"
+    if value is None:
+        raise ValueError("TOML does not support null values.")
+
+    raise TypeError(f"unsupported TOML value type: {type(value).__name__}")
+
+
+def _format_toml_key(key: str) -> str:
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", key):
+        return key
+
+    return _format_toml_value(key)

--- a/python/src/hhat_lang/core/config/utils.py
+++ b/python/src/hhat_lang/core/config/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import wraps
 from pathlib import Path
-from typing import Callable, Any
+from typing import Any, Callable
 
 conversion_types: dict[str, Callable[[Path], dict | Any]] = dict()
 """
@@ -28,12 +28,16 @@ def insert_reader(ext: str) -> Callable:
 def read_json(file: Path) -> dict:
     import json
 
-    return json.load(open(file))
+    with file.open(encoding="utf-8") as fp:
+        return json.load(fp)
 
 
 @insert_reader("toml")
 def read_toml(file: Path) -> Any:
-    raise NotImplementedError("reading TOML config files for H-hat not implemented yet.")
+    import tomllib
+
+    with file.open("rb") as fp:
+        return tomllib.load(fp)
 
 
 @insert_reader("yaml")
@@ -41,10 +45,14 @@ def read_yaml(file: Path) -> dict:
     raise NotImplementedError("reading YAML config files for H-hat not implemented yet.")
 
 
-def read_file(file: Path) -> dict | Any:
+def read_file(file: Path | str) -> dict | Any:
     """
     Reads H-hat's project configuration file.
     """
 
-    read_fn: Callable[[Path], dict | Any] = conversion_types.get(file.name.split(".")[-1])
+    file = Path(file)
+    read_fn: Callable[[Path], dict | Any] = conversion_types.get(file.suffix.removeprefix("."))
+    if read_fn is None:
+        raise ValueError(f"unsupported H-hat configuration file type: {file.suffix}")
+
     return read_fn(file)

--- a/python/tests/core/test_quantum_device_config.py
+++ b/python/tests/core/test_quantum_device_config.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+from hhat_lang.core.config.quantum_device import (
+    QuantumDevice,
+    QuantumDeviceConfiguration,
+    QuantumDeviceSpecs,
+    QuantumLowLevelLanguage,
+    read_quantum_device_config,
+    write_quantum_device_config,
+)
+from hhat_lang.core.config.utils import read_file
+
+
+def _dummy_device(
+    name: str,
+    *,
+    active: bool,
+    vendor: str,
+    kind: str,
+    platform: str,
+    paradigms: tuple[str, ...],
+    qubits: int,
+    qll_name: str,
+    package_name: str,
+    extension: str,
+) -> QuantumDevice:
+    return QuantumDevice(
+        name=name,
+        is_active=active,
+        vendor=vendor,
+        device_kind=kind,
+        device_platform=platform,
+        computation_paradigm=paradigms,
+        specs=QuantumDeviceSpecs(
+            max_n_qubits=qubits,
+            qubit_topology={"kind": "line", "couplings": [[0, 1], [1, 2]]},
+        ),
+        qll=QuantumLowLevelLanguage(
+            name=qll_name,
+            package_name=package_name,
+            package_version="0.1.0",
+            file_extension=extension,
+        ),
+        extra={"region": "test", "notes": f"{vendor} dummy device"},
+    )
+
+
+def _dummy_config() -> QuantumDeviceConfiguration:
+    return QuantumDeviceConfiguration(
+        devices=(
+            _dummy_device(
+                "AerSimulator",
+                active=True,
+                vendor="Qiskit",
+                kind="simulator",
+                platform="superconducting",
+                paradigms=("gate",),
+                qubits=32,
+                qll_name="openqasm",
+                package_name="hhat_lang.low_level.quantum_lang.openqasm.v2",
+                extension="qasm",
+            ),
+            _dummy_device(
+                "default.qubit",
+                active=True,
+                vendor="PennyLane",
+                kind="simulator",
+                platform="state-vector",
+                paradigms=("gate",),
+                qubits=20,
+                qll_name="openqasm",
+                package_name="hhat_lang.low_level.quantum_lang.openqasm.v2",
+                extension="qasm",
+            ),
+            _dummy_device(
+                "H1-1",
+                active=False,
+                vendor="Quantinuum",
+                kind="device",
+                platform="trapped ions",
+                paradigms=("gate",),
+                qubits=20,
+                qll_name="openqasm",
+                package_name="hhat_lang.low_level.quantum_lang.openqasm.v2",
+                extension="qasm",
+            ),
+            _dummy_device(
+                "Starmon-5",
+                active=False,
+                vendor="Quantum Inspire",
+                kind="device",
+                platform="superconducting",
+                paradigms=("gate",),
+                qubits=5,
+                qll_name="openqasm",
+                package_name="hhat_lang.low_level.quantum_lang.openqasm.v2",
+                extension="qasm",
+            ),
+            _dummy_device(
+                "Aquila",
+                active=False,
+                vendor="QuEra",
+                kind="device",
+                platform="neutral atoms",
+                paradigms=("analog",),
+                qubits=256,
+                qll_name="bloqade",
+                package_name="hhat_lang.low_level.quantum_lang.bloqade",
+                extension="json",
+            ),
+        )
+    )
+
+
+def test_write_and_read_quantum_device_config(tmp_path):
+    path = tmp_path / "quantum_config.toml"
+
+    write_quantum_device_config(_dummy_config(), path)
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+
+    assert raw["title"] == "H-hat Compiler Quantum Device Configuration"
+    assert raw["available"]["active_devices"] == ["AerSimulator", "default.qubit"]
+    assert len(raw["devices"]) == 5
+
+    loaded = read_quantum_device_config(path)
+
+    assert [device.name for device in loaded.active_devices] == ["AerSimulator", "default.qubit"]
+    assert loaded.devices[0].specs.qubit_topology["couplings"] == [[0, 1], [1, 2]]
+    assert loaded.devices[-1].qll.package_name == "hhat_lang.low_level.quantum_lang.bloqade"
+    assert read_file(str(path))["available"]["active_devices"] == ["AerSimulator", "default.qubit"]
+
+
+def test_read_manually_written_quantum_device_config(tmp_path):
+    path = tmp_path / "quantum_config.toml"
+    path.write_text(
+        """
+title = "H-hat Compiler Quantum Device Configuration"
+version = "0.1.0"
+
+[[devices]]
+name = "Tuna-17"
+is_active = true
+vendor = "QuTech"
+device_kind = "device"
+device_platform = "superconducting"
+computation_paradigm = ["gate"]
+
+[devices.specs]
+max_n_qubits = 17
+qubit_topology = { kind = "grid", rows = 4, columns = 5 }
+
+[devices.qll]
+name = "openqasm"
+package_name = "hhat_lang.low_level.quantum_lang.openqasm.v2"
+package_version = "2.0"
+file_extension = "qasm"
+
+[devices.extra]
+calibration = "manual"
+""",
+        encoding="utf-8",
+    )
+
+    config = read_quantum_device_config(path)
+
+    assert config.active_devices[0].name == "Tuna-17"
+    assert config.devices[0].specs.qubit_topology["kind"] == "grid"
+    assert config.devices[0].extra["calibration"] == "manual"
+
+
+def test_quantum_device_config_requires_active_device():
+    config = QuantumDeviceConfiguration(
+        devices=(
+            _dummy_device(
+                "inactive-sim",
+                active=False,
+                vendor="Qiskit",
+                kind="simulator",
+                platform="state-vector",
+                paradigms=("gate",),
+                qubits=8,
+                qll_name="openqasm",
+                package_name="hhat_lang.low_level.quantum_lang.openqasm.v2",
+                extension="qasm",
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match="at least one active device"):
+        write_quantum_device_config(config)


### PR DESCRIPTION
﻿Implements the standalone quantum device TOML configuration reader/writer portion of #63.

This adds a small independent config layer that can read and write `quantum_config.toml` data without wiring it into compiler initialization yet.

Changes:
- add `hhat_lang.core.config.quantum_device` dataclasses for quantum device specs, QLL package metadata, devices, active-device filtering, validation, TOML read, and TOML write
- write an `[available]` section with active devices for quick reader access
- implement stdlib `tomllib` support in the existing config `read_file()` path
- make `read_file()` accept both `Path` and `str` and report unsupported config suffixes explicitly
- add tests covering round-trip writing/reading, manually written TOML, dummy vendor/device examples, and the at-least-one-active-device rule

Scope note:
This PR does not yet auto-extract vendor/package metadata or connect the config into compiler initialization. It provides the independent reader/writer utility and validation layer requested by the issue so that compiler integration can consume a stable config object next.

Validation:
- `python -m py_compile python\\src\\hhat_lang\\core\\config\\utils.py python\\src\\hhat_lang\\core\\config\\quantum_device.py python\\tests\\core\\test_quantum_device_config.py`
- `python -m ruff check python\\src\\hhat_lang\\core\\config\\utils.py python\\src\\hhat_lang\\core\\config\\quantum_device.py python\\tests\\core\\test_quantum_device_config.py`
- `python -m ruff format --check python\\src\\hhat_lang\\core\\config\\utils.py python\\src\\hhat_lang\\core\\config\\quantum_device.py python\\tests\\core\\test_quantum_device_config.py --line-length=100`
- `python/tests/core/test_quantum_device_config.py -q` -> 3 passed

Existing unrelated local collection failures observed:
- `python/tests/test_cli.py` currently fails during collection with `TypeError: unsupported operand type(s) for /: 'str' and 'str'` in `hhat_lang.toolchain.project.__init__`
- `python/tests/core` currently has pre-existing collection failures from circular imports in `core.data.var_def`/`var_assignment` and `KeyError: u32` in `test_types.py`

### Generative AI/LLM disclosure

Code and Logic Architecture/Design:

- [ ] The code and logic architecture/design contain no generative AI/LLM
- [ ] The code and logic architecture/design are partially performed by generative AI/LLM
  - **0%** performed by the author(s)
- [x] The code and logic architecture/design are fully performed by generative AI/LLM

Code content:

- [ ] The code contains no generative AI/LLM work
- [ ] The code is partially written by generative AI/L
  - **0%** performed by the author(s)
- [x] The code is fully written by generative AI/LLM

Code review:

- [ ] The code review contains no generative AI/LLM
- [ ] The code review is partially done by generative AI/LLM
  - **0%** performed by the author(s)
- [x] The code review is fully done by generative AI/LLM

Code tests:

- [ ] The code tests contain no generative AI/LLM
- [ ] The code tests are partially written by generative AI/LLM
  - **0%** performed by the author(s)
- [x] The code tests are fully written by generative AI/LLM
