### PR TITLE
Add quantum device TOML configuration support

### DIFF
--- a/python/src/hhat_lang/core/config/__init__.py
+++ b/python/src/hhat_lang/core/config/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from hhat_lang.core.config.quantum_device import (
+    QuantumDevice,
+    QuantumDeviceConfig,
+    QuantumDeviceSpecs,
+    QuantumLowLevelLanguage,
+    load_quantum_config,
+    write_quantum_config,
+)

--- a/python/src/hhat_lang/core/config/quantum_device.py
+++ b/python/src/hhat_lang/core/config/quantum_device.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from hhat_lang.core.config.utils import read_file
+
+QuantumDeviceKind = Literal["simulator", "device"]
+TomlValue = str | int | float | bool | list[Any] | dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class QuantumDeviceSpecs:
+    max_n_qubits: int
+    qubit_topology: TomlValue = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QuantumDeviceSpecs:
+        if "max_n_qubits" not in data:
+            raise ValueError("quantum device specs must define 'max_n_qubits'")
+        return cls(
+            max_n_qubits=int(data["max_n_qubits"]),
+            qubit_topology=data.get("qubit_topology"),
+        )
+
+    def as_dict(self) -> dict[str, TomlValue]:
+        return {
+            "max_n_qubits": self.max_n_qubits,
+            "qubit_topology": self.qubit_topology,
+        }
+
+
+@dataclass(frozen=True)
+class QuantumLowLevelLanguage:
+    name: str
+    package_name: str
+    package_version: str
+    file_extension: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QuantumLowLevelLanguage:
+        return cls(
+            name=_require_text(data, "name"),
+            package_name=_require_text(data, "package_name"),
+            package_version=_require_text(data, "package_version"),
+            file_extension=_require_text(data, "file_extension"),
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "package_name": self.package_name,
+            "package_version": self.package_version,
+            "file_extension": self.file_extension,
+        }
+
+
+@dataclass(frozen=True)
+class QuantumDevice:
+    name: str
+    is_active: bool
+    vendor: str
+    device_kind: QuantumDeviceKind
+    device_platform: str
+    computation_paradigm: tuple[str, ...]
+    specs: QuantumDeviceSpecs
+    qll: QuantumLowLevelLanguage
+    extra: dict[str, TomlValue] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QuantumDevice:
+        kind = _require_text(data, "device_kind")
+        if kind not in {"simulator", "device"}:
+            raise ValueError("device_kind must be 'simulator' or 'device'")
+
+        return cls(
+            name=_require_text(data, "name"),
+            is_active=bool(data.get("is_active", False)),
+            vendor=_require_text(data, "vendor"),
+            device_kind=kind,
+            device_platform=_require_text(data, "device_platform"),
+            computation_paradigm=tuple(str(value) for value in data.get("computation_paradigm", ())),
+            specs=QuantumDeviceSpecs.from_dict(data.get("specs", {})),
+            qll=QuantumLowLevelLanguage.from_dict(data.get("qll", {})),
+            extra=dict(data.get("extra", {})),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "is_active": self.is_active,
+            "vendor": self.vendor,
+            "device_kind": self.device_kind,
+            "device_platform": self.device_platform,
+            "computation_paradigm": list(self.computation_paradigm),
+            "specs": self.specs.as_dict(),
+            "qll": self.qll.as_dict(),
+            "extra": self.extra,
+        }
+
+
+@dataclass(frozen=True)
+class QuantumDeviceConfig:
+    title: str
+    version: str
+    devices: tuple[QuantumDevice, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QuantumDeviceConfig:
+        devices = tuple(QuantumDevice.from_dict(device) for device in data.get("devices", ()))
+        config = cls(
+            title=_require_text(data, "title"),
+            version=_require_text(data, "version"),
+            devices=devices,
+        )
+        config.validate()
+        return config
+
+    @property
+    def active_devices(self) -> tuple[QuantumDevice, ...]:
+        return tuple(device for device in self.devices if device.is_active)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "version": self.version,
+            "devices": [device.as_dict() for device in self.devices],
+        }
+
+    def validate(self) -> None:
+        if not self.devices:
+            raise ValueError("quantum device config must contain at least one device")
+        if not self.active_devices:
+            raise ValueError("quantum device config must contain at least one active device")
+
+
+def load_quantum_config(file: Path | str = "quantum_config.toml") -> QuantumDeviceConfig:
+    return QuantumDeviceConfig.from_dict(read_file(Path(file)))
+
+
+def write_quantum_config(config: QuantumDeviceConfig, file: Path | str = "quantum_config.toml") -> None:
+    config.validate()
+    Path(file).write_text(_render_quantum_config(config))
+
+
+def _render_quantum_config(config: QuantumDeviceConfig) -> str:
+    lines = [
+        f"title = {_toml_value(config.title)}",
+        f"version = {_toml_value(config.version)}",
+        "",
+    ]
+
+    for device in config.devices:
+        lines.extend(
+            [
+                "[[devices]]",
+                f"name = {_toml_value(device.name)}",
+                f"is_active = {_toml_value(device.is_active)}",
+                f"vendor = {_toml_value(device.vendor)}",
+                f"device_kind = {_toml_value(device.device_kind)}",
+                f"device_platform = {_toml_value(device.device_platform)}",
+                f"computation_paradigm = {_toml_value(list(device.computation_paradigm))}",
+                "[devices.specs]",
+                f"max_n_qubits = {_toml_value(device.specs.max_n_qubits)}",
+            ]
+        )
+        if device.specs.qubit_topology is not None:
+            lines.append(f"qubit_topology = {_toml_value(device.specs.qubit_topology)}")
+
+        lines.extend(
+            [
+                "[devices.qll]",
+                f"name = {_toml_value(device.qll.name)}",
+                f"package_name = {_toml_value(device.qll.package_name)}",
+                f"package_version = {_toml_value(device.qll.package_version)}",
+                f"file_extension = {_toml_value(device.qll.file_extension)}",
+                "[devices.extra]",
+            ]
+        )
+        for key, value in sorted(device.extra.items()):
+            lines.append(f"{key} = {_toml_value(value)}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _require_text(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"quantum device config must define non-empty '{key}'")
+    return value
+
+
+def _toml_value(value: TomlValue) -> str:
+    match value:
+        case bool():
+            return str(value).lower()
+        case int() | float():
+            return str(value)
+        case str():
+            return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+        case list() | tuple():
+            return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+        case dict():
+            items = ", ".join(f"{key} = {_toml_value(item)}" for key, item in sorted(value.items()))
+            return "{ " + items + " }"
+        case None:
+            raise ValueError("None is not a valid TOML value")
+        case _:
+            raise TypeError(f"unsupported TOML value type: {type(value).__name__}")

--- a/python/src/hhat_lang/core/config/utils.py
+++ b/python/src/hhat_lang/core/config/utils.py
@@ -33,7 +33,10 @@ def read_json(file: Path) -> dict:
 
 @insert_reader("toml")
 def read_toml(file: Path) -> Any:
-    raise NotImplementedError("reading TOML config files for H-hat not implemented yet.")
+    import tomllib
+
+    with open(file, "rb") as config_file:
+        return tomllib.load(config_file)
 
 
 @insert_reader("yaml")

--- a/python/tests/core/test_quantum_device_config.py
+++ b/python/tests/core/test_quantum_device_config.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from hhat_lang.core.config.quantum_device import (
+    QuantumDevice,
+    QuantumDeviceConfig,
+    QuantumDeviceSpecs,
+    QuantumLowLevelLanguage,
+    load_quantum_config,
+    write_quantum_config,
+)
+from hhat_lang.core.config.utils import read_file
+
+
+def _device(
+    name: str,
+    vendor: str,
+    platform: str,
+    qll_name: str,
+    active: bool = False,
+    max_n_qubits: int = 32,
+) -> QuantumDevice:
+    return QuantumDevice(
+        name=name,
+        is_active=active,
+        vendor=vendor,
+        device_kind="simulator" if active else "device",
+        device_platform=platform,
+        computation_paradigm=("gate",),
+        specs=QuantumDeviceSpecs(
+            max_n_qubits=max_n_qubits,
+            qubit_topology={"kind": "line", "size": max_n_qubits},
+        ),
+        qll=QuantumLowLevelLanguage(
+            name=qll_name,
+            package_name=f"hhat-{qll_name}",
+            package_version="0.1.0",
+            file_extension="qasm" if qll_name == "openqasm" else "nqasm",
+        ),
+        extra={"source": vendor.lower().replace(" ", "-")},
+    )
+
+
+def test_quantum_device_config_round_trips_toml(tmp_path):
+    config_path = tmp_path / "quantum_config.toml"
+    config = QuantumDeviceConfig(
+        title="H-hat Compiler Quantum Device Configuration",
+        version="0.1.0",
+        devices=(
+            _device("AerSimulator", "Qiskit", "superconducting", "openqasm", active=True),
+            _device("default.qubit", "PennyLane", "simulator", "openqasm"),
+            _device("H-Series", "Quantinuum", "trapped ions", "openqasm", max_n_qubits=20),
+            _device("Starmon-5", "Quantum Inspire", "superconducting", "openqasm", max_n_qubits=5),
+            _device("Aquila", "QuEra", "neutral atoms", "openqasm", max_n_qubits=256),
+        ),
+    )
+
+    write_quantum_config(config, config_path)
+    loaded = load_quantum_config(config_path)
+
+    assert loaded == config
+    assert [device.name for device in loaded.active_devices] == ["AerSimulator"]
+    assert read_file(config_path)["devices"][0]["specs"]["max_n_qubits"] == 32
+
+
+def test_quantum_device_config_requires_an_active_device(tmp_path):
+    config_path = tmp_path / "quantum_config.toml"
+    config = QuantumDeviceConfig(
+        title="H-hat Compiler Quantum Device Configuration",
+        version="0.1.0",
+        devices=(_device("inactive-aer", "Qiskit", "superconducting", "openqasm"),),
+    )
+
+    with pytest.raises(ValueError, match="at least one active device"):
+        write_quantum_config(config, config_path)
+
+
+def test_quantum_device_config_rejects_invalid_device_kind():
+    raw_config = {
+        "title": "H-hat Compiler Quantum Device Configuration",
+        "version": "0.1.0",
+        "devices": [
+            {
+                "name": "broken",
+                "is_active": True,
+                "vendor": "Example",
+                "device_kind": "backend",
+                "device_platform": "simulator",
+                "computation_paradigm": ["gate"],
+                "specs": {"max_n_qubits": 4},
+                "qll": {
+                    "name": "openqasm",
+                    "package_name": "hhat-openqasm",
+                    "package_version": "0.1.0",
+                    "file_extension": "qasm",
+                },
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="device_kind"):
+        QuantumDeviceConfig.from_dict(raw_config)


### PR DESCRIPTION
Closes #63

Summary:
- Adds a typed `quantum_config.toml` model for quantum devices, specs, QLL package metadata, and extra vendor fields.
- Implements TOML reading via Python 3.12 `tomllib` and a small writer for H-hat quantum device configs.
- Validates that at least one device is active and rejects invalid `device_kind` values.
- Adds round-trip tests with dummy Qiskit, PennyLane, Quantinuum, Quantum Inspire, and QuEra-style devices.

Verification:
- `python -m pytest tests/core/test_quantum_device_config.py -q` (3 passed)
- `python -m compileall -q src/hhat_lang/core/config`
- `git diff --check`

unitaryHACK:
- Registered for unitaryHACK as `caijintaoduolacmeng-star`.

<!-- Please fill in the disclosure below: -->

### Generative AI/LLM disclosure

This contribution used Codex/LLM assistance. I checked the issue requirements, reviewed the generated changes and test results, and take responsibility for the submitted code.

Code and Logic Architecture/Design:

- [ ] The code and logic architecture/design contain no generative AI/LLM
- [x] The code and logic architecture/design are partially performed by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **30%** performed by the author(s)
- [ ] The code and logic architecture/design are fully performed by generative AI/LLM


Code content:

- [ ] The code contains no generative AI/LLM work
- [x] The code is partially written by generative AI/L
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **20%** performed by the author(s)
- [ ] The code is fully written by generative AI/LLM


Code review:

- [ ] The code review contains no generative AI/LLM
- [x] The code review is partially done by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **30%** performed by the author(s)
- [ ] The code review is fully done by generative AI/LLM


Code tests:

- [ ] The code tests contain no generative AI/LLM
- [x] The code tests are partially written by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **25%** performed by the author(s)
- [ ] The code tests are fully written by generative AI/LLM