### PR TITLE
feat: add configuration handler

### DIFF
--- a/rust/hhat_lang/Cargo.lock
+++ b/rust/hhat_lang/Cargo.lock
@@ -432,7 +432,9 @@ dependencies = [
  "cranelift-module",
  "itertools",
  "peg",
+ "serde",
  "strum",
+ "toml",
  "walkdir",
 ]
 
@@ -589,6 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -609,6 +612,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -657,6 +669,45 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
@@ -801,3 +852,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"

--- a/rust/hhat_lang/Cargo.toml
+++ b/rust/hhat_lang/Cargo.toml
@@ -14,3 +14,5 @@ cranelift = "0.128.3"
 cranelift-module = "0.128.3"
 cranelift-jit = "0.128.3"
 strum = "0.28.0"
+toml = { version = "1.1.2", features = ["preserve_order", "serde"] }
+serde = { version = "1.0.228", features = ["derive"] }

--- a/rust/hhat_lang/src/config/base.rs
+++ b/rust/hhat_lang/src/config/base.rs
@@ -1,119 +1,243 @@
-use std::collections::HashMap;
-use std::fs;
+mod inner {
+    use std::collections::HashMap;
+    use std::fs;
 
-use serde::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
-struct Config {
-    title: String,
-    version: String,
-    devices: Vec<Device>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
-enum DeviceKind {
-    Simulator,
-    Device,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
-struct DeviceSpecs {
-    max_n_qubits: u32,
-    qubit_topology: Vec<(u32, u32)>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
-struct DeviceQuantumLowLevel {
-    name: String,
-    package_name: String,
-    package_version: String,
-    file_extension: String,
-}
-
-#[derive(Serialize, Deserialize)]
-struct Device {
-    name: String,
-    is_active: bool,
-    vendor: String,
-    device_kind: DeviceKind,
-    device_platform: String,
-    computation_paradigm: Vec<String>,
-    device_specs: DeviceSpecs,
-    qll: DeviceQuantumLowLevel,
-    extra: Option<HashMap<String, toml::Value>>,
-}
-
-impl Config {
-    fn new(title: String, version: String, mut devices: Vec<Device>) -> Result<Self, String> {
-        let check_active_device = devices.iter().find(|device| device.is_active).is_some();
-
-        if check_active_device {
-            devices.sort_by(|device_a, device_b| {
-                device_a.is_active.cmp(&device_b.is_active).reverse()
-            });
-            Ok(Self {
-                title,
-                version,
-                devices,
-            })
-        } else {
-            Err("At least one device must be active.".to_string())
-        }
+    #[derive(Serialize, Deserialize)]
+    pub struct Config {
+        pub title: String,
+        pub version: String,
+        devices: Vec<Device>,
     }
 
-    fn to_file(&self, path: &str) -> Result<(), String> {
-        let toml_string = toml::to_string(self).map_err(|e| e.to_string())?;
-        fs::write(path, toml_string).map_err(|e| e.to_string())
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+    pub enum DeviceKind {
+        Simulator,
+        Device,
     }
 
-    fn from_file(path: &str) -> Result<Self, String> {
-        let toml_string = fs::read_to_string(path).map_err(|e| e.to_string())?;
-        let mut config: Config = toml::from_str(&toml_string).map_err(|e| e.to_string())?;
-        config
-            .devices
-            .sort_by(|device_a, device_b| device_a.is_active.cmp(&device_b.is_active).reverse());
-
-        match config.devices.iter().find(|device| device.is_active) {
-            Some(_) => Ok(config),
-            None => Err("At least one device must be active.".to_string()),
-        }
+    #[derive(Serialize, Deserialize, PartialEq, Eq)]
+    pub struct DeviceSpecs {
+        pub max_n_qubits: u32,
+        pub qubit_topology: Vec<(u32, u32)>,
     }
-}
 
-// Since toml::Value doesn't implement PartialEq, we define the equality up to the `extra` field
-impl PartialEq for Config {
-    fn eq(&self, other: &Self) -> bool {
-        if self.title != other.title {
-            return false;
-        }
-        if self.version != other.version {
-            return false;
-        }
-        if self.devices.len() != other.devices.len() {
-            return false;
-        }
-        for (device_a, device_b) in self.devices.iter().zip(other.devices.iter()) {
-            if device_a.name != device_b.name
-                || device_a.is_active != device_b.is_active
-                || device_a.vendor != device_b.vendor
-                || device_a.device_kind != device_b.device_kind
-                || device_a.device_platform != device_b.device_platform
-                || device_a.computation_paradigm != device_b.computation_paradigm
-                || device_a.device_specs != device_b.device_specs
-                || device_a.qll != device_b.qll
-            {
-                return false;
+    #[derive(Serialize, Deserialize, PartialEq, Eq)]
+    pub struct DeviceQuantumLowLevel {
+        pub name: String,
+        pub package_name: String,
+        pub package_version: String,
+        pub file_extension: String,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct Device {
+        pub name: String,
+        pub is_active: bool,
+        pub vendor: String,
+        pub device_kind: DeviceKind,
+        pub device_platform: String,
+        pub computation_paradigm: Vec<String>,
+        pub device_specs: DeviceSpecs,
+        pub qll: DeviceQuantumLowLevel,
+        pub extra: Option<HashMap<String, toml::Value>>,
+    }
+
+    impl Config {
+        pub fn new(
+            title: String,
+            version: String,
+            mut devices: Vec<Device>,
+        ) -> Result<Self, String> {
+            let check_active_device = devices.iter().find(|device| device.is_active).is_some();
+
+            if check_active_device {
+                devices.sort_by(|device_a, device_b| {
+                    device_a.is_active.cmp(&device_b.is_active).reverse()
+                });
+                Ok(Self {
+                    title,
+                    version,
+                    devices,
+                })
+            } else {
+                Err("At least one device must be active.".to_string())
             }
         }
 
-        true
+        pub fn to_file(&self, path: &str) -> Result<(), String> {
+            let toml_string = toml::to_string(self).map_err(|e| e.to_string())?;
+            fs::write(path, toml_string).map_err(|e| e.to_string())
+        }
+
+        pub fn from_file(path: &str) -> Result<Self, String> {
+            let toml_string = fs::read_to_string(path).map_err(|e| e.to_string())?;
+            let mut config: Config = toml::from_str(&toml_string).map_err(|e| e.to_string())?;
+            config.devices.sort_by(|device_a, device_b| {
+                device_a.is_active.cmp(&device_b.is_active).reverse()
+            });
+
+            match config.devices.iter().find(|device| device.is_active) {
+                Some(_) => Ok(config),
+                None => Err("At least one device must be active.".to_string()),
+            }
+        }
+
+        pub fn remove_device(&mut self, index: usize) -> Result<Device, String> {
+            if index < self.devices.len() {
+                if self.devices[index].is_active
+                    && self
+                        .devices
+                        .iter()
+                        .filter(|device| device.is_active)
+                        .count()
+                        == 1
+                {
+                    Err("Can't remove the only active device.".to_string())
+                } else {
+                    Ok(self.devices.remove(index))
+                }
+            } else {
+                Err(format!("Index {} not found.", index))
+            }
+        }
+
+        pub fn replace_device(&mut self, index: usize, device: Device) -> Result<(), String> {
+            if index < self.devices.len() {
+                if self.devices[index].is_active
+                    && !device.is_active
+                    && self.devices.iter().filter(|d| d.is_active).count() == 1
+                {
+                    Err("Can't replace the only active device with an inactive one.".to_string())
+                } else {
+                    self.devices[index] = device;
+                    Ok(())
+                }
+            } else {
+                Err(format!("Index {} not found.", index))
+            }
+        }
+
+        pub fn add_device(&mut self, device: Device) {
+            if !device.is_active {
+                self.devices.push(device);
+            } else {
+                // We want to shift as few elements as possible, so we find the first inactive device and insert to its left
+                let insert_index = self.devices.partition_point(|device| device.is_active);
+                self.devices.insert(insert_index, device);
+            }
+        }
+
+        // No mut version so that changing a device must be done via replace_device, which ensures the sort
+        // and the fact that at least one device must be active
+        pub fn get_devices(&self) -> &[Device] {
+            &self.devices
+        }
     }
+
+    // Since toml::Value doesn't implement PartialEq, we define the equality up to the `extra` field
+    impl PartialEq for Config {
+        fn eq(&self, other: &Self) -> bool {
+            if self.title != other.title {
+                return false;
+            }
+            if self.version != other.version {
+                return false;
+            }
+            if self.devices.len() != other.devices.len() {
+                return false;
+            }
+            for (device_a, device_b) in self.devices.iter().zip(other.devices.iter()) {
+                if device_a.name != device_b.name
+                    || device_a.is_active != device_b.is_active
+                    || device_a.vendor != device_b.vendor
+                    || device_a.device_kind != device_b.device_kind
+                    || device_a.device_platform != device_b.device_platform
+                    || device_a.computation_paradigm != device_b.computation_paradigm
+                    || device_a.device_specs != device_b.device_specs
+                    || device_a.qll != device_b.qll
+                {
+                    return false;
+                }
+            }
+
+            true
+        }
+    }
+    impl Eq for Config {}
 }
-impl Eq for Config {}
+
+pub use inner::*;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::collections::HashMap;
+    use std::fs;
+
+    use super::{Config, Device, DeviceKind, DeviceQuantumLowLevel, DeviceSpecs};
+
+    pub(self) fn active_device(name: String) -> Device {
+        Device {
+            name,
+            is_active: true,
+            vendor: "IBM".to_string(),
+            device_kind: DeviceKind::Simulator,
+            device_platform: "superconducting".to_string(),
+            computation_paradigm: vec!["gate".to_string()],
+            device_specs: DeviceSpecs {
+                max_n_qubits: 5,
+                qubit_topology: vec![
+                    (0, 1),
+                    (1, 0),
+                    (1, 2),
+                    (2, 1),
+                    (2, 3),
+                    (3, 2),
+                    (3, 4),
+                    (4, 3),
+                ],
+            },
+            qll: DeviceQuantumLowLevel {
+                name: "openqasm".to_string(),
+                package_name: "qiskit_ibm_runtime".to_string(),
+                package_version: "0.47.0".to_string(),
+                file_extension: "qasm".to_string(),
+            },
+            extra: None,
+        }
+    }
+
+    pub(self) fn inactive_device(name: String) -> Device {
+        Device {
+            name,
+            is_active: false,
+            vendor: "IBM".to_string(),
+            device_kind: DeviceKind::Device,
+            device_platform: "superconducting".to_string(),
+            computation_paradigm: vec!["gate".to_string()],
+            device_specs: DeviceSpecs {
+                max_n_qubits: 5,
+                qubit_topology: vec![
+                    (0, 1),
+                    (1, 0),
+                    (1, 2),
+                    (2, 1),
+                    (2, 3),
+                    (3, 2),
+                    (3, 4),
+                    (4, 3),
+                ],
+            },
+            qll: DeviceQuantumLowLevel {
+                name: "openqasm".to_string(),
+                package_name: "qiskit_ibm_runtime".to_string(),
+                package_version: "0.47.0".to_string(),
+                file_extension: "qasm".to_string(),
+            },
+            extra: Some(HashMap::from([("retired".to_string(), true.into())])),
+        }
+    }
 
     /// Check that creating a config using `Config::new` sorts the devices and check that the serialization works.
     #[test]
@@ -122,62 +246,8 @@ mod tests {
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
             vec![
-                Device {
-                    name: "ManilaV2".to_string(),
-                    is_active: false,
-                    vendor: "IBM".to_string(),
-                    device_kind: DeviceKind::Device,
-                    device_platform: "superconducting".to_string(),
-                    computation_paradigm: vec!["gate".to_string()],
-                    device_specs: DeviceSpecs {
-                        max_n_qubits: 5,
-                        qubit_topology: vec![
-                            (0, 1),
-                            (1, 0),
-                            (1, 2),
-                            (2, 1),
-                            (2, 3),
-                            (3, 2),
-                            (3, 4),
-                            (4, 3),
-                        ],
-                    },
-                    qll: DeviceQuantumLowLevel {
-                        name: "openqasm".to_string(),
-                        package_name: "qiskit_ibm_runtime".to_string(),
-                        package_version: "0.47.0".to_string(),
-                        file_extension: "qasm".to_string(),
-                    },
-                    extra: Some(HashMap::from([("retired".to_string(), true.into())])),
-                },
-                Device {
-                    name: "FakeManilaV2".to_string(),
-                    is_active: true,
-                    vendor: "IBM".to_string(),
-                    device_kind: DeviceKind::Simulator,
-                    device_platform: "superconducting".to_string(),
-                    computation_paradigm: vec!["gate".to_string()],
-                    device_specs: DeviceSpecs {
-                        max_n_qubits: 5,
-                        qubit_topology: vec![
-                            (0, 1),
-                            (1, 0),
-                            (1, 2),
-                            (2, 1),
-                            (2, 3),
-                            (3, 2),
-                            (3, 4),
-                            (4, 3),
-                        ],
-                    },
-                    qll: DeviceQuantumLowLevel {
-                        name: "openqasm".to_string(),
-                        package_name: "qiskit_ibm_runtime".to_string(),
-                        package_version: "0.47.0".to_string(),
-                        file_extension: "qasm".to_string(),
-                    },
-                    extra: None,
-                },
+                inactive_device("ManilaV2".to_string()),
+                active_device("FakeManilaV2".to_string()),
             ],
         )
         .unwrap();
@@ -359,36 +429,12 @@ retired = true
         let config = Config::new(
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
-            vec![Device {
-                name: "ManilaV2".to_string(),
-                is_active: false,
-                vendor: "IBM".to_string(),
-                device_kind: DeviceKind::Device,
-                device_platform: "superconducting".to_string(),
-                computation_paradigm: vec!["gate".to_string()],
-                device_specs: DeviceSpecs {
-                    max_n_qubits: 5,
-                    qubit_topology: vec![
-                        (0, 1),
-                        (1, 0),
-                        (1, 2),
-                        (2, 1),
-                        (2, 3),
-                        (3, 2),
-                        (3, 4),
-                        (4, 3),
-                    ],
-                },
-                qll: DeviceQuantumLowLevel {
-                    name: "openqasm".to_string(),
-                    package_name: "qiskit_ibm_runtime".to_string(),
-                    package_version: "0.47.0".to_string(),
-                    file_extension: "qasm".to_string(),
-                },
-                extra: Some(HashMap::from([("retired".to_string(), true.into())])),
-            }],
+            vec![inactive_device("ManilaV2".to_string())],
         );
-        assert!(config.is_err());
+        match config {
+            Ok(_) => panic!("Config should not have been created successfully."),
+            Err(e) => assert_eq!(e, "At least one device must be active.".to_string(),),
+        }
     }
 
     #[test]
@@ -424,6 +470,272 @@ retired = true
         .unwrap();
         let derived_config = Config::from_file("test_from_file_with_no_active_devices.toml");
         fs::remove_file("test_from_file_with_no_active_devices.toml").unwrap();
-        assert!(derived_config.is_err());
+        match derived_config {
+            Ok(_) => panic!("Config should not have been created successfully."),
+            Err(e) => assert_eq!(e, "At least one device must be active.".to_string(),),
+        }
+    }
+
+    #[test]
+    fn test_remove_inactive_device() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                inactive_device("ManilaV2".to_string()),
+                active_device("FakeManilaV2".to_string()),
+            ],
+        )
+        .unwrap();
+
+        // 1 is the inactive one since it has been sorted
+        let removed_result = config.remove_device(1);
+        assert!(removed_result.is_ok());
+        let removed_device = removed_result.unwrap();
+        assert_eq!(removed_device.name, "ManilaV2");
+        assert_eq!(config.get_devices().len(), 1);
+        assert_eq!(config.get_devices()[0].name, "FakeManilaV2");
+    }
+
+    #[test]
+    fn test_remove_active_device_with_other_active_present() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                active_device("FakeManilaV2".to_string()),
+                inactive_device("ManilaV2".to_string()),
+                active_device("FakeManilaV3".to_string()),
+            ],
+        )
+        .unwrap();
+
+        // 1 is active since it has been sorted
+        let removed_result = config.remove_device(1);
+        assert!(removed_result.is_ok());
+        let removed_device = removed_result.unwrap();
+        assert_eq!(removed_device.name, "FakeManilaV3");
+        assert_eq!(config.get_devices().len(), 2);
+        assert_eq!(config.get_devices()[0].name, "FakeManilaV2");
+        assert_eq!(config.get_devices()[1].name, "ManilaV2");
+    }
+
+    #[test]
+    fn test_remove_only_active_device_fails() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![active_device("FakeManilaV2".to_string())],
+        )
+        .unwrap();
+        match config.remove_device(0) {
+            Ok(_) => panic!("Should not have been able to remove the only active device."),
+            Err(e) => assert_eq!(e, "Can't remove the only active device.".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_remove_device_out_of_bounds_fails() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![active_device("FakeManilaV2".to_string())],
+        )
+        .unwrap();
+        match config.remove_device(1) {
+            Ok(_) => panic!("Should not have been able to remove this index."),
+            Err(e) => assert_eq!(e, "Index 1 not found.".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_replace_inactive_device() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                active_device("FakeManilaV2".to_string()),
+                inactive_device("ManilaV2".to_string()),
+            ],
+        )
+        .unwrap();
+        assert!(
+            config
+                .replace_device(1, active_device("FakeManilaV3".to_string()))
+                .is_ok()
+        );
+        assert_eq!(config.get_devices()[1].name, "FakeManilaV3");
+    }
+
+    #[test]
+    fn test_replace_active_device_with_active() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                active_device("FakeManilaV2".to_string()),
+                inactive_device("ManilaV2".to_string()),
+            ],
+        )
+        .unwrap();
+        assert!(
+            config
+                .replace_device(0, active_device("FakeManilaV3".to_string()))
+                .is_ok()
+        );
+        assert_eq!(config.get_devices()[0].name, "FakeManilaV3");
+    }
+
+    #[test]
+    fn test_replace_active_device_with_another_active() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                active_device("FakeManilaV2".to_string()),
+                inactive_device("ManilaV2".to_string()),
+            ],
+        )
+        .unwrap();
+        assert!(
+            config
+                .replace_device(0, active_device("FakeManilaV3".to_string()))
+                .is_ok()
+        );
+        assert_eq!(config.get_devices()[0].name, "FakeManilaV3");
+        assert_eq!(config.get_devices()[1].name, "ManilaV2");
+    }
+
+    #[test]
+    fn test_replace_only_active_device_with_inactive_fails() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                active_device("FakeManilaV2".to_string()),
+                inactive_device("ManilaV2".to_string()),
+            ],
+        )
+        .unwrap();
+        match config.replace_device(0, inactive_device("ManilaV3".to_string())) {
+            Ok(_) => panic!(
+                "Should not have been able to replace the only active device with an inactive one."
+            ),
+            Err(e) => assert_eq!(
+                e,
+                "Can't replace the only active device with an inactive one.".to_string()
+            ),
+        }
+    }
+
+    #[test]
+    fn test_replace_device_out_of_bounds_fails() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                active_device("FakeManilaV2".to_string()),
+                inactive_device("ManilaV2".to_string()),
+            ],
+        )
+        .unwrap();
+        match config.replace_device(5, active_device("FakeManilaV2".to_string())) {
+            Ok(_) => {
+                panic!("Should not have been able to replace a device at an out-of-bounds index.")
+            }
+            Err(e) => assert_eq!(e, "Index 5 not found.".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_add_inactive_device_appends() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                active_device("FakeManilaV2".to_string()),
+                inactive_device("ManilaV2".to_string()),
+            ],
+        )
+        .unwrap();
+        config.add_device(inactive_device("ManilaV3".to_string()));
+        let devices = config.get_devices();
+        assert_eq!(devices.len(), 3);
+        assert_eq!(devices.last().unwrap().name, "ManilaV3");
+    }
+
+    #[test]
+    fn test_add_active_device_placed_before_inactive() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                active_device("FakeManilaV2".to_string()),
+                inactive_device("ManilaV2".to_string()),
+            ],
+        )
+        .unwrap();
+        config.add_device(active_device("FakeManilaV3".to_string()));
+        let devices = config.get_devices();
+        assert_eq!(devices.len(), 3);
+        assert_eq!(devices[0].name, "FakeManilaV2");
+        assert_eq!(devices[1].name, "FakeManilaV3");
+        assert_eq!(devices[2].name, "ManilaV2");
+    }
+
+    #[test]
+    fn test_access_config() {
+        let mut config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![active_device("FakeManilaV2".to_string())],
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.title,
+            "H-hat Compiler Quantum Device Configuration".to_string()
+        );
+        assert_eq!(config.version, "0.1.0".to_string());
+        assert_eq!(config.get_devices().len(), 1);
+        assert_eq!(config.get_devices()[0].name, "FakeManilaV2".to_string());
+        assert_eq!(config.get_devices()[0].is_active, true);
+        assert_eq!(config.get_devices()[0].vendor, "IBM".to_string());
+        assert_eq!(config.get_devices()[0].device_kind, DeviceKind::Simulator);
+        assert_eq!(
+            config.get_devices()[0].device_platform,
+            "superconducting".to_string()
+        );
+        assert_eq!(
+            config.get_devices()[0].computation_paradigm,
+            vec!["gate".to_string()]
+        );
+        assert_eq!(config.get_devices()[0].device_specs.max_n_qubits, 5);
+        assert_eq!(
+            config.get_devices()[0].device_specs.qubit_topology,
+            vec![
+                (0, 1),
+                (1, 0),
+                (1, 2),
+                (2, 1),
+                (2, 3),
+                (3, 2),
+                (3, 4),
+                (4, 3),
+            ]
+        );
+        assert_eq!(config.get_devices()[0].qll.name, "openqasm".to_string());
+        assert_eq!(
+            config.get_devices()[0].qll.package_name,
+            "qiskit_ibm_runtime".to_string()
+        );
+        assert_eq!(
+            config.get_devices()[0].qll.package_version,
+            "0.47.0".to_string()
+        );
+        assert_eq!(
+            config.get_devices()[0].qll.file_extension,
+            "qasm".to_string()
+        );
     }
 }

--- a/rust/hhat_lang/src/config/base.rs
+++ b/rust/hhat_lang/src/config/base.rs
@@ -42,6 +42,10 @@ mod inner {
         pub device_specs: DeviceSpecs,
         pub qll: DeviceQuantumLowLevel,
         pub extra: Option<HashMap<String, toml::Value>>,
+        /// The priority of a device controls the order in which they appear when serialized in a configuration file.
+        /// For instance, the device with the highest priority will be the first to appear in the configuration file.
+        /// If two devices have the same priority, then they are ordered according to the order they had when they were added
+        /// to the `Config` object, with the oldest appearing first.
         priority: isize,
     }
 

--- a/rust/hhat_lang/src/config/base.rs
+++ b/rust/hhat_lang/src/config/base.rs
@@ -1,0 +1,429 @@
+use std::collections::HashMap;
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Config {
+    title: String,
+    version: String,
+    devices: Vec<Device>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
+enum DeviceKind {
+    Simulator,
+    Device,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
+struct DeviceSpecs {
+    max_n_qubits: u32,
+    qubit_topology: Vec<(u32, u32)>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
+struct DeviceQuantumLowLevel {
+    name: String,
+    package_name: String,
+    package_version: String,
+    file_extension: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Device {
+    name: String,
+    is_active: bool,
+    vendor: String,
+    device_kind: DeviceKind,
+    device_platform: String,
+    computation_paradigm: Vec<String>,
+    device_specs: DeviceSpecs,
+    qll: DeviceQuantumLowLevel,
+    extra: Option<HashMap<String, toml::Value>>,
+}
+
+impl Config {
+    fn new(title: String, version: String, mut devices: Vec<Device>) -> Result<Self, String> {
+        let check_active_device = devices.iter().find(|device| device.is_active).is_some();
+
+        if check_active_device {
+            devices.sort_by(|device_a, device_b| {
+                device_a.is_active.cmp(&device_b.is_active).reverse()
+            });
+            Ok(Self {
+                title,
+                version,
+                devices,
+            })
+        } else {
+            Err("At least one device must be active.".to_string())
+        }
+    }
+
+    fn to_file(&self, path: &str) -> Result<(), String> {
+        let toml_string = toml::to_string(self).map_err(|e| e.to_string())?;
+        fs::write(path, toml_string).map_err(|e| e.to_string())
+    }
+
+    fn from_file(path: &str) -> Result<Self, String> {
+        let toml_string = fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let mut config: Config = toml::from_str(&toml_string).map_err(|e| e.to_string())?;
+        config
+            .devices
+            .sort_by(|device_a, device_b| device_a.is_active.cmp(&device_b.is_active).reverse());
+
+        match config.devices.iter().find(|device| device.is_active) {
+            Some(_) => Ok(config),
+            None => Err("At least one device must be active.".to_string()),
+        }
+    }
+}
+
+// Since toml::Value doesn't implement PartialEq, we define the equality up to the `extra` field
+impl PartialEq for Config {
+    fn eq(&self, other: &Self) -> bool {
+        if self.title != other.title {
+            return false;
+        }
+        if self.version != other.version {
+            return false;
+        }
+        if self.devices.len() != other.devices.len() {
+            return false;
+        }
+        for (device_a, device_b) in self.devices.iter().zip(other.devices.iter()) {
+            if device_a.name != device_b.name
+                || device_a.is_active != device_b.is_active
+                || device_a.vendor != device_b.vendor
+                || device_a.device_kind != device_b.device_kind
+                || device_a.device_platform != device_b.device_platform
+                || device_a.computation_paradigm != device_b.computation_paradigm
+                || device_a.device_specs != device_b.device_specs
+                || device_a.qll != device_b.qll
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+impl Eq for Config {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Check that creating a config using `Config::new` sorts the devices and check that the serialization works.
+    #[test]
+    fn test_serialize_dummy_qiskit_device() {
+        let config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![
+                Device {
+                    name: "ManilaV2".to_string(),
+                    is_active: false,
+                    vendor: "IBM".to_string(),
+                    device_kind: DeviceKind::Device,
+                    device_platform: "superconducting".to_string(),
+                    computation_paradigm: vec!["gate".to_string()],
+                    device_specs: DeviceSpecs {
+                        max_n_qubits: 5,
+                        qubit_topology: vec![
+                            (0, 1),
+                            (1, 0),
+                            (1, 2),
+                            (2, 1),
+                            (2, 3),
+                            (3, 2),
+                            (3, 4),
+                            (4, 3),
+                        ],
+                    },
+                    qll: DeviceQuantumLowLevel {
+                        name: "openqasm".to_string(),
+                        package_name: "qiskit_ibm_runtime".to_string(),
+                        package_version: "0.47.0".to_string(),
+                        file_extension: "qasm".to_string(),
+                    },
+                    extra: Some(HashMap::from([("retired".to_string(), true.into())])),
+                },
+                Device {
+                    name: "FakeManilaV2".to_string(),
+                    is_active: true,
+                    vendor: "IBM".to_string(),
+                    device_kind: DeviceKind::Simulator,
+                    device_platform: "superconducting".to_string(),
+                    computation_paradigm: vec!["gate".to_string()],
+                    device_specs: DeviceSpecs {
+                        max_n_qubits: 5,
+                        qubit_topology: vec![
+                            (0, 1),
+                            (1, 0),
+                            (1, 2),
+                            (2, 1),
+                            (2, 3),
+                            (3, 2),
+                            (3, 4),
+                            (4, 3),
+                        ],
+                    },
+                    qll: DeviceQuantumLowLevel {
+                        name: "openqasm".to_string(),
+                        package_name: "qiskit_ibm_runtime".to_string(),
+                        package_version: "0.47.0".to_string(),
+                        file_extension: "qasm".to_string(),
+                    },
+                    extra: None,
+                },
+            ],
+        )
+        .unwrap();
+        config
+            .to_file("test_serialize_dummy_qiskit_device.toml")
+            .unwrap();
+        let written_data = fs::read_to_string("test_serialize_dummy_qiskit_device.toml").unwrap();
+        assert_eq!(
+            written_data,
+            r#"title = "H-hat Compiler Quantum Device Configuration"
+version = "0.1.0"
+
+[[devices]]
+name = "FakeManilaV2"
+is_active = true
+vendor = "IBM"
+device_kind = "Simulator"
+device_platform = "superconducting"
+computation_paradigm = ["gate"]
+
+[devices.device_specs]
+max_n_qubits = 5
+qubit_topology = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]]
+
+[devices.qll]
+name = "openqasm"
+package_name = "qiskit_ibm_runtime"
+package_version = "0.47.0"
+file_extension = "qasm"
+
+[[devices]]
+name = "ManilaV2"
+is_active = false
+vendor = "IBM"
+device_kind = "Device"
+device_platform = "superconducting"
+computation_paradigm = ["gate"]
+
+[devices.device_specs]
+max_n_qubits = 5
+qubit_topology = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]]
+
+[devices.qll]
+name = "openqasm"
+package_name = "qiskit_ibm_runtime"
+package_version = "0.47.0"
+file_extension = "qasm"
+
+[devices.extra]
+retired = true
+"#
+        );
+        fs::remove_file("test_serialize_dummy_qiskit_device.toml").unwrap();
+    }
+
+    #[test]
+    fn test_deserialize_dummy_qiskit_device() {
+        fs::write(
+            "test_deserialize_dummy_qiskit_device.toml",
+            r#"
+                title = "H-hat Compiler Quantum Device Configuration"
+                version = "0.1.0"
+
+                [[devices]]
+                name = "FakeManilaV2"
+                is_active = true
+                vendor = "IBM"
+                device_kind = "Simulator"
+                device_platform = "superconducting"
+                computation_paradigm = ["gate"]
+
+                [devices.device_specs]
+                max_n_qubits = 5
+                qubit_topology = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]]
+
+                [devices.qll]
+                name = "openqasm"
+                package_name = "qiskit_ibm_runtime"
+                package_version = "0.47.0"
+                file_extension = "qasm"
+
+                [[devices]]
+                name = "ManilaV2"
+                is_active = false
+                vendor = "IBM"
+                device_kind = "Device"
+                device_platform = "superconducting"
+                computation_paradigm = ["gate"]
+
+                [devices.device_specs]
+                max_n_qubits = 5
+                qubit_topology = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]]
+
+                [devices.qll]
+                name = "openqasm"
+                package_name = "qiskit_ibm_runtime"
+                package_version = "0.47.0"
+                file_extension = "qasm"
+
+                [devices.extra]
+                retired = true
+            "#,
+        )
+        .unwrap();
+        if let Ok(derived_config) = Config::from_file("test_deserialize_dummy_qiskit_device.toml") {
+            fs::remove_file("test_deserialize_dummy_qiskit_device.toml").unwrap();
+            let config = Config::new(
+                "H-hat Compiler Quantum Device Configuration".to_string(),
+                "0.1.0".to_string(),
+                vec![
+                    Device {
+                        name: "ManilaV2".to_string(),
+                        is_active: false,
+                        vendor: "IBM".to_string(),
+                        device_kind: DeviceKind::Device,
+                        device_platform: "superconducting".to_string(),
+                        computation_paradigm: vec!["gate".to_string()],
+                        device_specs: DeviceSpecs {
+                            max_n_qubits: 5,
+                            qubit_topology: vec![
+                                (0, 1),
+                                (1, 0),
+                                (1, 2),
+                                (2, 1),
+                                (2, 3),
+                                (3, 2),
+                                (3, 4),
+                                (4, 3),
+                            ],
+                        },
+                        qll: DeviceQuantumLowLevel {
+                            name: "openqasm".to_string(),
+                            package_name: "qiskit_ibm_runtime".to_string(),
+                            package_version: "0.47.0".to_string(),
+                            file_extension: "qasm".to_string(),
+                        },
+                        extra: Some(HashMap::from([("retired".to_string(), true.into())])),
+                    },
+                    Device {
+                        name: "FakeManilaV2".to_string(),
+                        is_active: true,
+                        vendor: "IBM".to_string(),
+                        device_kind: DeviceKind::Simulator,
+                        device_platform: "superconducting".to_string(),
+                        computation_paradigm: vec!["gate".to_string()],
+                        device_specs: DeviceSpecs {
+                            max_n_qubits: 5,
+                            qubit_topology: vec![
+                                (0, 1),
+                                (1, 0),
+                                (1, 2),
+                                (2, 1),
+                                (2, 3),
+                                (3, 2),
+                                (3, 4),
+                                (4, 3),
+                            ],
+                        },
+                        qll: DeviceQuantumLowLevel {
+                            name: "openqasm".to_string(),
+                            package_name: "qiskit_ibm_runtime".to_string(),
+                            package_version: "0.47.0".to_string(),
+                            file_extension: "qasm".to_string(),
+                        },
+                        extra: None,
+                    },
+                ],
+            )
+            .unwrap();
+            assert!(derived_config == config);
+        } else {
+            fs::remove_file("test_deserialize_dummy_qiskit_device.toml").unwrap();
+            panic!("Failed to deserialize the config file.");
+        }
+    }
+
+    #[test]
+    fn test_new_with_no_active_device() {
+        let config = Config::new(
+            "H-hat Compiler Quantum Device Configuration".to_string(),
+            "0.1.0".to_string(),
+            vec![Device {
+                name: "ManilaV2".to_string(),
+                is_active: false,
+                vendor: "IBM".to_string(),
+                device_kind: DeviceKind::Device,
+                device_platform: "superconducting".to_string(),
+                computation_paradigm: vec!["gate".to_string()],
+                device_specs: DeviceSpecs {
+                    max_n_qubits: 5,
+                    qubit_topology: vec![
+                        (0, 1),
+                        (1, 0),
+                        (1, 2),
+                        (2, 1),
+                        (2, 3),
+                        (3, 2),
+                        (3, 4),
+                        (4, 3),
+                    ],
+                },
+                qll: DeviceQuantumLowLevel {
+                    name: "openqasm".to_string(),
+                    package_name: "qiskit_ibm_runtime".to_string(),
+                    package_version: "0.47.0".to_string(),
+                    file_extension: "qasm".to_string(),
+                },
+                extra: Some(HashMap::from([("retired".to_string(), true.into())])),
+            }],
+        );
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_from_file_with_no_active_devices() {
+        fs::write(
+            "test_from_file_with_no_active_devices.toml",
+            r#"
+                title = "H-hat Compiler Quantum Device Configuration"
+                version = "0.1.0"
+
+                [[devices]]
+                name = "ManilaV2"
+                is_active = false
+                vendor = "IBM"
+                device_kind = "Device"
+                device_platform = "superconducting"
+                computation_paradigm = ["gate"]
+
+                [devices.device_specs]
+                max_n_qubits = 5
+                qubit_topology = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]]
+
+                [devices.qll]
+                name = "openqasm"
+                package_name = "qiskit_ibm_runtime"
+                package_version = "0.47.0"
+                file_extension = "qasm"
+
+                [devices.extra]
+                retired = true
+            "#,
+        )
+        .unwrap();
+        let derived_config = Config::from_file("test_from_file_with_no_active_devices.toml");
+        fs::remove_file("test_from_file_with_no_active_devices.toml").unwrap();
+        assert!(derived_config.is_err());
+    }
+}

--- a/rust/hhat_lang/src/config/base.rs
+++ b/rust/hhat_lang/src/config/base.rs
@@ -42,7 +42,7 @@ mod inner {
         pub device_specs: DeviceSpecs,
         pub qll: DeviceQuantumLowLevel,
         pub extra: Option<HashMap<String, toml::Value>>,
-        priority: isize
+        priority: isize,
     }
 
     impl Device {
@@ -83,9 +83,7 @@ mod inner {
             version: String,
             mut devices: Vec<Device>,
         ) -> Result<Self, String> {
-            devices.sort_by(|device_a, device_b| {
-                device_b.priority.cmp(&device_a.priority)
-            });
+            devices.sort_by(|device_a, device_b| device_b.priority.cmp(&device_a.priority));
             Ok(Self {
                 title,
                 version,
@@ -101,9 +99,9 @@ mod inner {
         pub fn from_file(path: &str) -> Result<Self, String> {
             let toml_string = fs::read_to_string(path).map_err(|e| e.to_string())?;
             let mut config: Config = toml::from_str(&toml_string).map_err(|e| e.to_string())?;
-            config.devices.sort_by(|device_a, device_b| {
-                device_b.priority.cmp(&device_a.priority)
-            });
+            config
+                .devices
+                .sort_by(|device_a, device_b| device_b.priority.cmp(&device_a.priority));
             Ok(config)
         }
 
@@ -123,7 +121,9 @@ mod inner {
 
         pub fn add_device(&mut self, new_device: Device) {
             // We want to shift as few elements as possible, so we find the first inactive device and insert to its left
-            let insert_index = self.devices.partition_point(|device| device.priority > new_device.priority);
+            let insert_index = self
+                .devices
+                .partition_point(|device| device.priority > new_device.priority);
             self.devices.insert(insert_index, new_device);
         }
 
@@ -183,7 +183,11 @@ mod tests {
             name,
             is_active,
             "IBM".to_string(),
-            if is_active { DeviceKind::Simulator } else { DeviceKind::Device },
+            if is_active {
+                DeviceKind::Simulator
+            } else {
+                DeviceKind::Device
+            },
             "superconducting".to_string(),
             vec!["gate".to_string()],
             DeviceSpecs {
@@ -205,8 +209,12 @@ mod tests {
                 package_version: "0.47.0".to_string(),
                 file_extension: "qasm".to_string(),
             },
-            if is_active { None } else { Some(HashMap::from([("retired".to_string(), true.into())])) },
-            priority
+            if is_active {
+                None
+            } else {
+                Some(HashMap::from([("retired".to_string(), true.into())]))
+            },
+            priority,
         )
     }
 
@@ -334,7 +342,7 @@ retired = true
                 "0.1.0".to_string(),
                 vec![
                     get_ibm_device("ManilaV2".to_string(), false, -2),
-                    get_ibm_device("FakeManilaV2".to_string(), true, 5)
+                    get_ibm_device("FakeManilaV2".to_string(), true, 5),
                 ],
             )
             .unwrap();
@@ -353,7 +361,7 @@ retired = true
             vec![
                 get_ibm_device("ManilaV2".to_string(), false, 0),
                 get_ibm_device("FakeManilaV2".to_string(), true, 1),
-                get_ibm_device("ManilaV3".to_string(), false, 2)
+                get_ibm_device("ManilaV3".to_string(), false, 2),
             ],
         )
         .unwrap();

--- a/rust/hhat_lang/src/config/base.rs
+++ b/rust/hhat_lang/src/config/base.rs
@@ -42,6 +42,39 @@ mod inner {
         pub device_specs: DeviceSpecs,
         pub qll: DeviceQuantumLowLevel,
         pub extra: Option<HashMap<String, toml::Value>>,
+        priority: isize
+    }
+
+    impl Device {
+        pub fn new(
+            name: String,
+            is_active: bool,
+            vendor: String,
+            device_kind: DeviceKind,
+            device_platform: String,
+            computation_paradigm: Vec<String>,
+            device_specs: DeviceSpecs,
+            qll: DeviceQuantumLowLevel,
+            extra: Option<HashMap<String, toml::Value>>,
+            priority: isize,
+        ) -> Self {
+            Self {
+                name,
+                is_active,
+                vendor,
+                device_kind,
+                device_platform,
+                computation_paradigm,
+                device_specs,
+                qll,
+                extra,
+                priority,
+            }
+        }
+
+        pub fn get_priority(&self) -> isize {
+            self.priority
+        }
     }
 
     impl Config {
@@ -50,20 +83,14 @@ mod inner {
             version: String,
             mut devices: Vec<Device>,
         ) -> Result<Self, String> {
-            let check_active_device = devices.iter().find(|device| device.is_active).is_some();
-
-            if check_active_device {
-                devices.sort_by(|device_a, device_b| {
-                    device_a.is_active.cmp(&device_b.is_active).reverse()
-                });
-                Ok(Self {
-                    title,
-                    version,
-                    devices,
-                })
-            } else {
-                Err("At least one device must be active.".to_string())
-            }
+            devices.sort_by(|device_a, device_b| {
+                device_b.priority.cmp(&device_a.priority)
+            });
+            Ok(Self {
+                title,
+                version,
+                devices,
+            })
         }
 
         pub fn to_file(&self, path: &str) -> Result<(), String> {
@@ -75,64 +102,38 @@ mod inner {
             let toml_string = fs::read_to_string(path).map_err(|e| e.to_string())?;
             let mut config: Config = toml::from_str(&toml_string).map_err(|e| e.to_string())?;
             config.devices.sort_by(|device_a, device_b| {
-                device_a.is_active.cmp(&device_b.is_active).reverse()
+                device_b.priority.cmp(&device_a.priority)
             });
-
-            match config.devices.iter().find(|device| device.is_active) {
-                Some(_) => Ok(config),
-                None => Err("At least one device must be active.".to_string()),
-            }
+            Ok(config)
         }
 
         pub fn remove_device(&mut self, index: usize) -> Result<Device, String> {
             if index < self.devices.len() {
-                if self.devices[index].is_active
-                    && self
-                        .devices
-                        .iter()
-                        .filter(|device| device.is_active)
-                        .count()
-                        == 1
-                {
-                    Err("Can't remove the only active device.".to_string())
-                } else {
-                    Ok(self.devices.remove(index))
-                }
+                Ok(self.devices.remove(index))
             } else {
                 Err(format!("Index {} not found.", index))
             }
         }
 
-        pub fn replace_device(&mut self, index: usize, device: Device) -> Result<(), String> {
-            if index < self.devices.len() {
-                if self.devices[index].is_active
-                    && !device.is_active
-                    && self.devices.iter().filter(|d| d.is_active).count() == 1
-                {
-                    Err("Can't replace the only active device with an inactive one.".to_string())
-                } else {
-                    self.devices[index] = device;
-                    Ok(())
-                }
-            } else {
-                Err(format!("Index {} not found.", index))
-            }
+        pub fn replace_device(&mut self, index: usize, device: Device) -> Result<Device, String> {
+            let removed = self.remove_device(index)?;
+            self.add_device(device);
+            Ok(removed)
         }
 
-        pub fn add_device(&mut self, device: Device) {
-            if !device.is_active {
-                self.devices.push(device);
-            } else {
-                // We want to shift as few elements as possible, so we find the first inactive device and insert to its left
-                let insert_index = self.devices.partition_point(|device| device.is_active);
-                self.devices.insert(insert_index, device);
-            }
+        pub fn add_device(&mut self, new_device: Device) {
+            // We want to shift as few elements as possible, so we find the first inactive device and insert to its left
+            let insert_index = self.devices.partition_point(|device| device.priority > new_device.priority);
+            self.devices.insert(insert_index, new_device);
         }
 
         // No mut version so that changing a device must be done via replace_device, which ensures the sort
-        // and the fact that at least one device must be active
         pub fn get_devices(&self) -> &[Device] {
             &self.devices
+        }
+
+        pub fn get_active_devices(&self) -> impl Iterator<Item = &Device> {
+            self.devices.iter().filter(|device| device.is_active)
         }
     }
 
@@ -177,15 +178,15 @@ mod tests {
 
     use super::{Config, Device, DeviceKind, DeviceQuantumLowLevel, DeviceSpecs};
 
-    pub(self) fn active_device(name: String) -> Device {
-        Device {
+    pub(self) fn get_ibm_device(name: String, is_active: bool, priority: isize) -> Device {
+        Device::new(
             name,
-            is_active: true,
-            vendor: "IBM".to_string(),
-            device_kind: DeviceKind::Simulator,
-            device_platform: "superconducting".to_string(),
-            computation_paradigm: vec!["gate".to_string()],
-            device_specs: DeviceSpecs {
+            is_active,
+            "IBM".to_string(),
+            if is_active { DeviceKind::Simulator } else { DeviceKind::Device },
+            "superconducting".to_string(),
+            vec!["gate".to_string()],
+            DeviceSpecs {
                 max_n_qubits: 5,
                 qubit_topology: vec![
                     (0, 1),
@@ -198,45 +199,15 @@ mod tests {
                     (4, 3),
                 ],
             },
-            qll: DeviceQuantumLowLevel {
+            DeviceQuantumLowLevel {
                 name: "openqasm".to_string(),
                 package_name: "qiskit_ibm_runtime".to_string(),
                 package_version: "0.47.0".to_string(),
                 file_extension: "qasm".to_string(),
             },
-            extra: None,
-        }
-    }
-
-    pub(self) fn inactive_device(name: String) -> Device {
-        Device {
-            name,
-            is_active: false,
-            vendor: "IBM".to_string(),
-            device_kind: DeviceKind::Device,
-            device_platform: "superconducting".to_string(),
-            computation_paradigm: vec!["gate".to_string()],
-            device_specs: DeviceSpecs {
-                max_n_qubits: 5,
-                qubit_topology: vec![
-                    (0, 1),
-                    (1, 0),
-                    (1, 2),
-                    (2, 1),
-                    (2, 3),
-                    (3, 2),
-                    (3, 4),
-                    (4, 3),
-                ],
-            },
-            qll: DeviceQuantumLowLevel {
-                name: "openqasm".to_string(),
-                package_name: "qiskit_ibm_runtime".to_string(),
-                package_version: "0.47.0".to_string(),
-                file_extension: "qasm".to_string(),
-            },
-            extra: Some(HashMap::from([("retired".to_string(), true.into())])),
-        }
+            if is_active { None } else { Some(HashMap::from([("retired".to_string(), true.into())])) },
+            priority
+        )
     }
 
     /// Check that creating a config using `Config::new` sorts the devices and check that the serialization works.
@@ -246,8 +217,8 @@ mod tests {
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
             vec![
-                inactive_device("ManilaV2".to_string()),
-                active_device("FakeManilaV2".to_string()),
+                get_ibm_device("ManilaV2".to_string(), false, 0),
+                get_ibm_device("FakeManilaV2".to_string(), true, 1),
             ],
         )
         .unwrap();
@@ -267,6 +238,7 @@ vendor = "IBM"
 device_kind = "Simulator"
 device_platform = "superconducting"
 computation_paradigm = ["gate"]
+priority = 1
 
 [devices.device_specs]
 max_n_qubits = 5
@@ -285,6 +257,7 @@ vendor = "IBM"
 device_kind = "Device"
 device_platform = "superconducting"
 computation_paradigm = ["gate"]
+priority = 0
 
 [devices.device_specs]
 max_n_qubits = 5
@@ -318,6 +291,7 @@ retired = true
                 device_kind = "Simulator"
                 device_platform = "superconducting"
                 computation_paradigm = ["gate"]
+                priority = 5
 
                 [devices.device_specs]
                 max_n_qubits = 5
@@ -336,6 +310,7 @@ retired = true
                 device_kind = "Device"
                 device_platform = "superconducting"
                 computation_paradigm = ["gate"]
+                priority = -2
 
                 [devices.device_specs]
                 max_n_qubits = 5
@@ -358,62 +333,8 @@ retired = true
                 "H-hat Compiler Quantum Device Configuration".to_string(),
                 "0.1.0".to_string(),
                 vec![
-                    Device {
-                        name: "ManilaV2".to_string(),
-                        is_active: false,
-                        vendor: "IBM".to_string(),
-                        device_kind: DeviceKind::Device,
-                        device_platform: "superconducting".to_string(),
-                        computation_paradigm: vec!["gate".to_string()],
-                        device_specs: DeviceSpecs {
-                            max_n_qubits: 5,
-                            qubit_topology: vec![
-                                (0, 1),
-                                (1, 0),
-                                (1, 2),
-                                (2, 1),
-                                (2, 3),
-                                (3, 2),
-                                (3, 4),
-                                (4, 3),
-                            ],
-                        },
-                        qll: DeviceQuantumLowLevel {
-                            name: "openqasm".to_string(),
-                            package_name: "qiskit_ibm_runtime".to_string(),
-                            package_version: "0.47.0".to_string(),
-                            file_extension: "qasm".to_string(),
-                        },
-                        extra: Some(HashMap::from([("retired".to_string(), true.into())])),
-                    },
-                    Device {
-                        name: "FakeManilaV2".to_string(),
-                        is_active: true,
-                        vendor: "IBM".to_string(),
-                        device_kind: DeviceKind::Simulator,
-                        device_platform: "superconducting".to_string(),
-                        computation_paradigm: vec!["gate".to_string()],
-                        device_specs: DeviceSpecs {
-                            max_n_qubits: 5,
-                            qubit_topology: vec![
-                                (0, 1),
-                                (1, 0),
-                                (1, 2),
-                                (2, 1),
-                                (2, 3),
-                                (3, 2),
-                                (3, 4),
-                                (4, 3),
-                            ],
-                        },
-                        qll: DeviceQuantumLowLevel {
-                            name: "openqasm".to_string(),
-                            package_name: "qiskit_ibm_runtime".to_string(),
-                            package_version: "0.47.0".to_string(),
-                            file_extension: "qasm".to_string(),
-                        },
-                        extra: None,
-                    },
+                    get_ibm_device("ManilaV2".to_string(), false, -2),
+                    get_ibm_device("FakeManilaV2".to_string(), true, 5)
                 ],
             )
             .unwrap();
@@ -425,113 +346,25 @@ retired = true
     }
 
     #[test]
-    fn test_new_with_no_active_device() {
-        let config = Config::new(
-            "H-hat Compiler Quantum Device Configuration".to_string(),
-            "0.1.0".to_string(),
-            vec![inactive_device("ManilaV2".to_string())],
-        );
-        match config {
-            Ok(_) => panic!("Config should not have been created successfully."),
-            Err(e) => assert_eq!(e, "At least one device must be active.".to_string(),),
-        }
-    }
-
-    #[test]
-    fn test_from_file_with_no_active_devices() {
-        fs::write(
-            "test_from_file_with_no_active_devices.toml",
-            r#"
-                title = "H-hat Compiler Quantum Device Configuration"
-                version = "0.1.0"
-
-                [[devices]]
-                name = "ManilaV2"
-                is_active = false
-                vendor = "IBM"
-                device_kind = "Device"
-                device_platform = "superconducting"
-                computation_paradigm = ["gate"]
-
-                [devices.device_specs]
-                max_n_qubits = 5
-                qubit_topology = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]]
-
-                [devices.qll]
-                name = "openqasm"
-                package_name = "qiskit_ibm_runtime"
-                package_version = "0.47.0"
-                file_extension = "qasm"
-
-                [devices.extra]
-                retired = true
-            "#,
-        )
-        .unwrap();
-        let derived_config = Config::from_file("test_from_file_with_no_active_devices.toml");
-        fs::remove_file("test_from_file_with_no_active_devices.toml").unwrap();
-        match derived_config {
-            Ok(_) => panic!("Config should not have been created successfully."),
-            Err(e) => assert_eq!(e, "At least one device must be active.".to_string(),),
-        }
-    }
-
-    #[test]
-    fn test_remove_inactive_device() {
+    fn test_remove_device() {
         let mut config = Config::new(
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
             vec![
-                inactive_device("ManilaV2".to_string()),
-                active_device("FakeManilaV2".to_string()),
+                get_ibm_device("ManilaV2".to_string(), false, 0),
+                get_ibm_device("FakeManilaV2".to_string(), true, 1),
+                get_ibm_device("ManilaV3".to_string(), false, 2)
             ],
         )
         .unwrap();
 
-        // 1 is the inactive one since it has been sorted
         let removed_result = config.remove_device(1);
         assert!(removed_result.is_ok());
         let removed_device = removed_result.unwrap();
-        assert_eq!(removed_device.name, "ManilaV2");
-        assert_eq!(config.get_devices().len(), 1);
-        assert_eq!(config.get_devices()[0].name, "FakeManilaV2");
-    }
-
-    #[test]
-    fn test_remove_active_device_with_other_active_present() {
-        let mut config = Config::new(
-            "H-hat Compiler Quantum Device Configuration".to_string(),
-            "0.1.0".to_string(),
-            vec![
-                active_device("FakeManilaV2".to_string()),
-                inactive_device("ManilaV2".to_string()),
-                active_device("FakeManilaV3".to_string()),
-            ],
-        )
-        .unwrap();
-
-        // 1 is active since it has been sorted
-        let removed_result = config.remove_device(1);
-        assert!(removed_result.is_ok());
-        let removed_device = removed_result.unwrap();
-        assert_eq!(removed_device.name, "FakeManilaV3");
+        assert_eq!(removed_device.name, "FakeManilaV2");
         assert_eq!(config.get_devices().len(), 2);
-        assert_eq!(config.get_devices()[0].name, "FakeManilaV2");
+        assert_eq!(config.get_devices()[0].name, "ManilaV3");
         assert_eq!(config.get_devices()[1].name, "ManilaV2");
-    }
-
-    #[test]
-    fn test_remove_only_active_device_fails() {
-        let mut config = Config::new(
-            "H-hat Compiler Quantum Device Configuration".to_string(),
-            "0.1.0".to_string(),
-            vec![active_device("FakeManilaV2".to_string())],
-        )
-        .unwrap();
-        match config.remove_device(0) {
-            Ok(_) => panic!("Should not have been able to remove the only active device."),
-            Err(e) => assert_eq!(e, "Can't remove the only active device.".to_string()),
-        }
     }
 
     #[test]
@@ -539,7 +372,7 @@ retired = true
         let mut config = Config::new(
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
-            vec![active_device("FakeManilaV2".to_string())],
+            vec![get_ibm_device("ManilaV2".to_string(), false, 0)],
         )
         .unwrap();
         match config.remove_device(1) {
@@ -549,83 +382,26 @@ retired = true
     }
 
     #[test]
-    fn test_replace_inactive_device() {
+    fn test_replace_device() {
         let mut config = Config::new(
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
             vec![
-                active_device("FakeManilaV2".to_string()),
-                inactive_device("ManilaV2".to_string()),
+                get_ibm_device("ManilaV2".to_string(), false, 0),
+                get_ibm_device("FakeManilaV2".to_string(), true, 1),
+                get_ibm_device("FakeManilaV3".to_string(), true, 2),
             ],
         )
         .unwrap();
         assert!(
             config
-                .replace_device(1, active_device("FakeManilaV3".to_string()))
+                .replace_device(1, get_ibm_device("ManilaV3".to_string(), false, 3))
                 .is_ok()
         );
+        assert_eq!(config.get_devices().len(), 3);
+        assert_eq!(config.get_devices()[0].name, "ManilaV3");
         assert_eq!(config.get_devices()[1].name, "FakeManilaV3");
-    }
-
-    #[test]
-    fn test_replace_active_device_with_active() {
-        let mut config = Config::new(
-            "H-hat Compiler Quantum Device Configuration".to_string(),
-            "0.1.0".to_string(),
-            vec![
-                active_device("FakeManilaV2".to_string()),
-                inactive_device("ManilaV2".to_string()),
-            ],
-        )
-        .unwrap();
-        assert!(
-            config
-                .replace_device(0, active_device("FakeManilaV3".to_string()))
-                .is_ok()
-        );
-        assert_eq!(config.get_devices()[0].name, "FakeManilaV3");
-    }
-
-    #[test]
-    fn test_replace_active_device_with_another_active() {
-        let mut config = Config::new(
-            "H-hat Compiler Quantum Device Configuration".to_string(),
-            "0.1.0".to_string(),
-            vec![
-                active_device("FakeManilaV2".to_string()),
-                inactive_device("ManilaV2".to_string()),
-            ],
-        )
-        .unwrap();
-        assert!(
-            config
-                .replace_device(0, active_device("FakeManilaV3".to_string()))
-                .is_ok()
-        );
-        assert_eq!(config.get_devices()[0].name, "FakeManilaV3");
-        assert_eq!(config.get_devices()[1].name, "ManilaV2");
-    }
-
-    #[test]
-    fn test_replace_only_active_device_with_inactive_fails() {
-        let mut config = Config::new(
-            "H-hat Compiler Quantum Device Configuration".to_string(),
-            "0.1.0".to_string(),
-            vec![
-                active_device("FakeManilaV2".to_string()),
-                inactive_device("ManilaV2".to_string()),
-            ],
-        )
-        .unwrap();
-        match config.replace_device(0, inactive_device("ManilaV3".to_string())) {
-            Ok(_) => panic!(
-                "Should not have been able to replace the only active device with an inactive one."
-            ),
-            Err(e) => assert_eq!(
-                e,
-                "Can't replace the only active device with an inactive one.".to_string()
-            ),
-        }
+        assert_eq!(config.get_devices()[2].name, "ManilaV2");
     }
 
     #[test]
@@ -634,12 +410,12 @@ retired = true
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
             vec![
-                active_device("FakeManilaV2".to_string()),
-                inactive_device("ManilaV2".to_string()),
+                get_ibm_device("FakeManilaV2".to_string(), true, 1),
+                get_ibm_device("ManilaV2".to_string(), false, 0),
             ],
         )
         .unwrap();
-        match config.replace_device(5, active_device("FakeManilaV2".to_string())) {
+        match config.replace_device(5, get_ibm_device("FakeManilaV3".to_string(), true, 6)) {
             Ok(_) => {
                 panic!("Should not have been able to replace a device at an out-of-bounds index.")
             }
@@ -648,39 +424,24 @@ retired = true
     }
 
     #[test]
-    fn test_add_inactive_device_appends() {
+    fn test_add_device() {
         let mut config = Config::new(
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
             vec![
-                active_device("FakeManilaV2".to_string()),
-                inactive_device("ManilaV2".to_string()),
+                get_ibm_device("FakeManilaV2".to_string(), true, 4),
+                get_ibm_device("ManilaV2".to_string(), false, 0),
+                get_ibm_device("ManilaV3".to_string(), false, 2),
             ],
         )
         .unwrap();
-        config.add_device(inactive_device("ManilaV3".to_string()));
+        config.add_device(get_ibm_device("FakeManilaV3".to_string(), true, 3));
         let devices = config.get_devices();
-        assert_eq!(devices.len(), 3);
-        assert_eq!(devices.last().unwrap().name, "ManilaV3");
-    }
-
-    #[test]
-    fn test_add_active_device_placed_before_inactive() {
-        let mut config = Config::new(
-            "H-hat Compiler Quantum Device Configuration".to_string(),
-            "0.1.0".to_string(),
-            vec![
-                active_device("FakeManilaV2".to_string()),
-                inactive_device("ManilaV2".to_string()),
-            ],
-        )
-        .unwrap();
-        config.add_device(active_device("FakeManilaV3".to_string()));
-        let devices = config.get_devices();
-        assert_eq!(devices.len(), 3);
+        assert_eq!(devices.len(), 4);
         assert_eq!(devices[0].name, "FakeManilaV2");
         assert_eq!(devices[1].name, "FakeManilaV3");
-        assert_eq!(devices[2].name, "ManilaV2");
+        assert_eq!(devices[2].name, "ManilaV3");
+        assert_eq!(devices[3].name, "ManilaV2");
     }
 
     #[test]
@@ -688,7 +449,10 @@ retired = true
         let mut config = Config::new(
             "H-hat Compiler Quantum Device Configuration".to_string(),
             "0.1.0".to_string(),
-            vec![active_device("FakeManilaV2".to_string())],
+            vec![
+                get_ibm_device("ManilaV2".to_string(), false, 0),
+                get_ibm_device("FakeManilaV2".to_string(), true, 1),
+            ],
         )
         .unwrap();
 
@@ -697,45 +461,57 @@ retired = true
             "H-hat Compiler Quantum Device Configuration".to_string()
         );
         assert_eq!(config.version, "0.1.0".to_string());
-        assert_eq!(config.get_devices().len(), 1);
+        assert_eq!(config.get_devices().len(), 2);
+
         assert_eq!(config.get_devices()[0].name, "FakeManilaV2".to_string());
+        assert_eq!(config.get_devices()[1].name, "ManilaV2".to_string());
+
         assert_eq!(config.get_devices()[0].is_active, true);
-        assert_eq!(config.get_devices()[0].vendor, "IBM".to_string());
+        assert_eq!(config.get_devices()[1].is_active, false);
+
+        assert_eq!(config.get_devices()[0].get_priority(), 1);
+        assert_eq!(config.get_devices()[1].get_priority(), 0);
+
         assert_eq!(config.get_devices()[0].device_kind, DeviceKind::Simulator);
-        assert_eq!(
-            config.get_devices()[0].device_platform,
-            "superconducting".to_string()
-        );
-        assert_eq!(
-            config.get_devices()[0].computation_paradigm,
-            vec!["gate".to_string()]
-        );
-        assert_eq!(config.get_devices()[0].device_specs.max_n_qubits, 5);
-        assert_eq!(
-            config.get_devices()[0].device_specs.qubit_topology,
-            vec![
-                (0, 1),
-                (1, 0),
-                (1, 2),
-                (2, 1),
-                (2, 3),
-                (3, 2),
-                (3, 4),
-                (4, 3),
-            ]
-        );
-        assert_eq!(config.get_devices()[0].qll.name, "openqasm".to_string());
-        assert_eq!(
-            config.get_devices()[0].qll.package_name,
-            "qiskit_ibm_runtime".to_string()
-        );
-        assert_eq!(
-            config.get_devices()[0].qll.package_version,
-            "0.47.0".to_string()
-        );
-        assert_eq!(
-            config.get_devices()[0].qll.file_extension,
-            "qasm".to_string()
-        );
+        assert_eq!(config.get_devices()[1].device_kind, DeviceKind::Device);
+
+        for i in [0, 1] {
+            assert_eq!(config.get_devices()[i].vendor, "IBM".to_string());
+            assert_eq!(
+                config.get_devices()[i].device_platform,
+                "superconducting".to_string()
+            );
+            assert_eq!(
+                config.get_devices()[i].computation_paradigm,
+                vec!["gate".to_string()]
+            );
+            assert_eq!(config.get_devices()[i].device_specs.max_n_qubits, 5);
+            assert_eq!(
+                config.get_devices()[i].device_specs.qubit_topology,
+                vec![
+                    (0, 1),
+                    (1, 0),
+                    (1, 2),
+                    (2, 1),
+                    (2, 3),
+                    (3, 2),
+                    (3, 4),
+                    (4, 3),
+                ]
+            );
+            assert_eq!(config.get_devices()[i].qll.name, "openqasm".to_string());
+            assert_eq!(
+                config.get_devices()[i].qll.package_name,
+                "qiskit_ibm_runtime".to_string()
+            );
+            assert_eq!(
+                config.get_devices()[i].qll.package_version,
+                "0.47.0".to_string()
+            );
+            assert_eq!(
+                config.get_devices()[i].qll.file_extension,
+                "qasm".to_string()
+            );
+        }
     }
 }

--- a/rust/hhat_lang/src/config/mod.rs
+++ b/rust/hhat_lang/src/config/mod.rs
@@ -1,1 +1,2 @@
+mod base;
 mod session;

--- a/rust/hhat_lang/src/config/mod.rs
+++ b/rust/hhat_lang/src/config/mod.rs
@@ -1,2 +1,2 @@
-mod base;
+pub mod base;
 mod session;


### PR DESCRIPTION
<!-- Place the PR description below, stating which issues it resolves. -->

Fixes #63. A `base` module has been added to `config`. This module contains the `Config` struct, which is to be used to read and write TOML configuration files using its `to_file` and `from_file` methods respectively. Devices are ordered according to whether they are active or not, and the `new` and `from_file` methods do check that at least one active device is present.

Note that I'm not entirely sure that this is what's expected for this issue, so don't hesitate to tell me what should be added/removed/changed! 

Concerning the LLM use, VS Code autocomplete gave me `reverse` and `find` which I did not know about (I would have went for a less idiomatic code without it). The rest comes from me, the `toml` crate documentation, and SO because I never had to read from and write to files in Rust :smile: 

<!-- Please fill in the disclosure below: -->

### Generative AI/LLM disclosure


Code and Logic Architecture/Design:

- [x] The code and logic architecture/design contain no generative AI/LLM
- [ ] The code and logic architecture/design are partially performed by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code and logic architecture/design are fully performed by generative AI/LLM


Code content:

- [ ] The code contains no generative AI/LLM work
- [x] The code is partially written by generative AI/L
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **90%** performed by the author(s)
- [ ] The code is fully written by generative AI/LLM


Code review:

- [x] The code review contains no generative AI/LLM
- [ ] The code review is partially done by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code review is fully done by generative AI/LLM


Code tests:

- [x] The code tests contain no generative AI/LLM
- [ ] The code tests are partially written by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code tests are fully written by generative AI/LLM


