### PR TITLE
feat: Add quantum memory layout for quantum data

### DIFF
--- a/rust/hhat_lang/hhat_core/src/layout/mod.rs
+++ b/rust/hhat_lang/hhat_core/src/layout/mod.rs
@@ -10,5 +10,6 @@
 pub mod arch;
 pub mod primitives;
 pub mod quantum;
+pub mod quantum_cache;
 mod adt;
 mod base;

--- a/rust/hhat_lang/hhat_core/src/layout/mod.rs
+++ b/rust/hhat_lang/hhat_core/src/layout/mod.rs
@@ -9,5 +9,6 @@
 
 pub mod arch;
 pub mod primitives;
+pub mod quantum;
 mod adt;
 mod base;

--- a/rust/hhat_lang/hhat_core/src/layout/quantum.rs
+++ b/rust/hhat_lang/hhat_core/src/layout/quantum.rs
@@ -1,0 +1,311 @@
+use std::collections::HashMap;
+
+use crate::frontend::types::{Ty, TyPrimitive};
+use crate::SymbolId;
+
+
+#[derive(Clone, Debug)]
+pub enum QuantumLayout {
+    Primitive(u32),
+    Struct(Vec<QuantumField>),
+    Enum(Vec<SymbolId>),
+}
+
+impl QuantumLayout {
+    pub fn qubits(&self) -> u32 {
+        match self {
+            QuantumLayout::Primitive(q) => *q,
+            QuantumLayout::Struct(fields) => fields.iter().map(|f| f.layout.qubits()).sum(),
+            QuantumLayout::Enum(_) => 1,
+        }
+    }
+
+    pub fn field(&self, name: &SymbolId) -> Option<&QuantumField> {
+        match self {
+            QuantumLayout::Struct(fields) => fields.iter().find(|f| f.name == *name),
+            _ => None,
+        }
+    }
+}
+
+
+#[derive(Clone, Debug)]
+pub struct QuantumField {
+    pub name: SymbolId,
+    pub offset: u32,
+    pub layout: QuantumLayout,
+}
+
+
+pub fn primitive_qubits(ty: &TyPrimitive) -> u32 {
+    match ty {
+        TyPrimitive::QBool => 1,
+        TyPrimitive::QU2 => 2,
+        TyPrimitive::QU3 => 3,
+        TyPrimitive::QU4 => 4,
+        TyPrimitive::QU8 => 8,
+        _ => 0,
+    }
+}
+
+
+#[derive(Default)]
+pub struct QuantumLayoutCache {
+    cache: HashMap<Ty, QuantumLayout>,
+}
+
+impl QuantumLayoutCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn layout_of(&mut self, ty: &Ty) -> QuantumLayout {
+        if let Some(layout) = self.cache.get(ty) {
+            return layout.clone();
+        }
+        let layout = self.build(ty);
+        self.cache.insert(ty.clone(), layout.clone());
+        layout
+    }
+
+    fn build(&mut self, ty: &Ty) -> QuantumLayout {
+        match ty {
+            Ty::Primitive(p) => QuantumLayout::Primitive(primitive_qubits(p)),
+            Ty::Struct(s) => {
+                let mut fields = Vec::new();
+                let mut offset = 0;
+                for (name, member) in s.iter() {
+                    if !member.is_quantum() {
+                        continue;
+                    }
+                    let layout = self.layout_of(member);
+                    let qubits = layout.qubits();
+                    fields.push(QuantumField {
+                        name: name.clone(),
+                        offset,
+                        layout,
+                    });
+                    offset += qubits;
+                }
+                QuantumLayout::Struct(fields)
+            }
+            Ty::Enum(e) => {
+                assert_eq!(
+                    e.variants.len(),
+                    2,
+                    "quantum enums must have exactly 2 variants, got {}",
+                    e.variants.len()
+                );
+                QuantumLayout::Enum(e.iter().map(|v| v.name().clone()).collect())
+            }
+            Ty::Array(_) => todo!("quantum array layout"),
+        }
+    }
+}
+
+
+#[derive(Clone, Debug)]
+pub struct QuantumInstruction {
+    pub ancilla: u32,
+}
+
+impl QuantumInstruction {
+    pub fn new(ancilla: u32) -> Self {
+        Self { ancilla }
+    }
+}
+
+
+#[derive(Clone, Debug)]
+pub struct QuantumProgram {
+    pub var: SymbolId,
+    pub layout: QuantumLayout,
+    pub instructions: Vec<QuantumInstruction>,
+    pub cast_attrs: Vec<SymbolId>,
+}
+
+impl QuantumProgram {
+    pub fn from_cast(var: SymbolId, ty: &Ty, cache: &mut QuantumLayoutCache) -> Self {
+        Self {
+            var,
+            layout: cache.layout_of(ty),
+            instructions: Vec::new(),
+            cast_attrs: Vec::new(),
+        }
+    }
+
+    pub fn add_instruction(&mut self, instr: QuantumInstruction) {
+        self.instructions.push(instr);
+    }
+
+    pub fn cast_attribute(&mut self, attr: SymbolId) {
+        self.cast_attrs.push(attr);
+    }
+
+    pub fn data_qubits(&self) -> u32 {
+        self.layout.qubits()
+    }
+
+    pub fn ancilla_qubits(&self) -> u32 {
+        self.instructions.iter().map(|i| i.ancilla).sum()
+    }
+
+    pub fn total_qubits(&self) -> u32 {
+        self.data_qubits() + self.ancilla_qubits()
+    }
+
+    pub fn classical_size(&self) -> u32 {
+        self.cast_attrs.len() as u32
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frontend::types::{TyEnum, TyStruct};
+    use crate::layout::arch::Arch;
+    use crate::layout::base::LayoutCache;
+
+    fn qsym(pos: u32) -> SymbolId {
+        SymbolId(pos, true)
+    }
+
+    fn csym(pos: u32) -> SymbolId {
+        SymbolId(pos, false)
+    }
+
+    fn bell_t() -> Ty {
+        let mut s = TyStruct::new(&qsym(0));
+        s.add_member(&qsym(1), Ty::Primitive(TyPrimitive::QBool));
+        s.add_member(&qsym(2), Ty::Primitive(TyPrimitive::QBool));
+        s.done();
+        Ty::Struct(s)
+    }
+
+    fn polarization() -> Ty {
+        let mut e = TyEnum::new(&qsym(10));
+        e.add_variant(&qsym(11), None);
+        e.add_variant(&qsym(12), None);
+        e.done();
+        Ty::Enum(e)
+    }
+
+    #[test]
+    fn primitive_qubit_counts() {
+        assert_eq!(primitive_qubits(&TyPrimitive::QBool), 1);
+        assert_eq!(primitive_qubits(&TyPrimitive::QU2), 2);
+        assert_eq!(primitive_qubits(&TyPrimitive::QU3), 3);
+        assert_eq!(primitive_qubits(&TyPrimitive::QU4), 4);
+        assert_eq!(primitive_qubits(&TyPrimitive::QU8), 8);
+    }
+
+    #[test]
+    fn struct_sums_members() {
+        let mut cache = QuantumLayoutCache::new();
+        let layout = cache.layout_of(&bell_t());
+        assert_eq!(layout.qubits(), 2);
+
+        let QuantumLayout::Struct(fields) = &layout else {
+            panic!("expected struct");
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].offset, 0);
+        assert_eq!(fields[1].offset, 1);
+        assert_eq!(layout.field(&qsym(2)).unwrap().offset, 1);
+    }
+
+    #[test]
+    fn enum_is_one_qubit() {
+        let mut cache = QuantumLayoutCache::new();
+        let layout = cache.layout_of(&polarization());
+        assert_eq!(layout.qubits(), 1);
+
+        let QuantumLayout::Enum(variants) = &layout else {
+            panic!("expected enum");
+        };
+        assert_eq!(variants, &vec![qsym(11), qsym(12)]);
+    }
+
+    #[test]
+    fn nested_struct_recurses() {
+        let mut nested = TyStruct::new(&qsym(20));
+        nested.add_member(&qsym(21), bell_t());
+        nested.add_member(&qsym(22), Ty::Primitive(TyPrimitive::QU4));
+        nested.add_member(&qsym(23), polarization());
+        nested.done();
+
+        let mut cache = QuantumLayoutCache::new();
+        let layout = cache.layout_of(&Ty::Struct(nested));
+        assert_eq!(layout.qubits(), 7);
+
+        let QuantumLayout::Struct(fields) = &layout else {
+            panic!("expected struct");
+        };
+        let offsets: Vec<u32> = fields.iter().map(|f| f.offset).collect();
+        assert_eq!(offsets, vec![0, 2, 6]);
+    }
+
+    #[test]
+    fn struct_ignores_classical_members() {
+        let mut mixed = TyStruct::new(&qsym(30));
+        mixed.add_member(&qsym(31), Ty::Primitive(TyPrimitive::QBool));
+        mixed.add_member(&csym(32), Ty::Primitive(TyPrimitive::Bool));
+        mixed.done();
+
+        let mut cache = QuantumLayoutCache::new();
+        let layout = cache.layout_of(&Ty::Struct(mixed));
+        assert_eq!(layout.qubits(), 1);
+
+        let QuantumLayout::Struct(fields) = &layout else {
+            panic!("expected struct");
+        };
+        assert_eq!(fields.len(), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn enum_rejects_more_than_two_variants() {
+        let mut e = TyEnum::new(&qsym(40));
+        e.add_variant(&qsym(41), None);
+        e.add_variant(&qsym(42), None);
+        e.add_variant(&qsym(43), None);
+        e.done();
+        QuantumLayoutCache::new().layout_of(&Ty::Enum(e));
+    }
+
+    #[test]
+    fn classical_layout_is_blind_quantum_layout_is_not() {
+        let mut classical = LayoutCache::new(Arch::get_arch64());
+        classical.initialize(Some(Arch::get_arch64()));
+        classical.insert_layout(&bell_t(), &Some(Arch::get_arch64()));
+        assert_eq!(classical.layout_of(&bell_t()).size(), 0);
+
+        let mut quantum = QuantumLayoutCache::new();
+        assert_eq!(
+            quantum.layout_of(&Ty::Primitive(TyPrimitive::QU4)).qubits(),
+            4
+        );
+        assert_eq!(quantum.layout_of(&bell_t()).qubits(), 2);
+    }
+
+    #[test]
+    fn quantum_program_totals() {
+        let mut cache = QuantumLayoutCache::new();
+
+        let prog =
+            QuantumProgram::from_cast(qsym(50), &Ty::Primitive(TyPrimitive::QU4), &mut cache);
+        assert_eq!(prog.total_qubits(), 4);
+        assert_eq!(prog.classical_size(), 0);
+
+        for ancilla in [0u32, 1, 2, 3] {
+            let mut prog = QuantumProgram::from_cast(qsym(50), &bell_t(), &mut cache);
+            prog.add_instruction(QuantumInstruction::new(ancilla));
+            prog.cast_attribute(qsym(2));
+            assert_eq!(prog.data_qubits(), 2);
+            assert_eq!(prog.ancilla_qubits(), ancilla);
+            assert_eq!(prog.total_qubits(), 2 + ancilla);
+            assert_eq!(prog.classical_size(), 1);
+        }
+    }
+}

--- a/rust/hhat_lang/hhat_core/src/layout/quantum.rs
+++ b/rust/hhat_lang/hhat_core/src/layout/quantum.rs
@@ -1,28 +1,26 @@
-use std::collections::HashMap;
-
-use crate::frontend::types::{Ty, TyPrimitive};
+use crate::frontend::types::TyPrimitive;
 use crate::SymbolId;
 
 
 #[derive(Clone, Debug)]
 pub enum QuantumLayout {
-    Primitive(u32),
-    Struct(Vec<QuantumField>),
-    Enum(Vec<SymbolId>),
+    Primitive(TyPrimitive),
+    Struct(SymbolId, Vec<QuantumField>),
+    Enum(SymbolId, [SymbolId; 2]),
 }
 
 impl QuantumLayout {
     pub fn qubits(&self) -> u32 {
         match self {
-            QuantumLayout::Primitive(q) => *q,
-            QuantumLayout::Struct(fields) => fields.iter().map(|f| f.layout.qubits()).sum(),
-            QuantumLayout::Enum(_) => 1,
+            QuantumLayout::Primitive(p) => primitive_qubits(p),
+            QuantumLayout::Struct(_, fields) => fields.iter().map(|f| f.layout.qubits()).sum(),
+            QuantumLayout::Enum(..) => 1,
         }
     }
 
     pub fn field(&self, name: &SymbolId) -> Option<&QuantumField> {
         match self {
-            QuantumLayout::Struct(fields) => fields.iter().find(|f| f.name == *name),
+            QuantumLayout::Struct(_, fields) => fields.iter().find(|f| f.name == *name),
             _ => None,
         }
     }
@@ -44,118 +42,16 @@ pub fn primitive_qubits(ty: &TyPrimitive) -> u32 {
         TyPrimitive::QU3 => 3,
         TyPrimitive::QU4 => 4,
         TyPrimitive::QU8 => 8,
-        _ => 0,
-    }
-}
-
-
-#[derive(Default)]
-pub struct QuantumLayoutCache {
-    cache: HashMap<Ty, QuantumLayout>,
-}
-
-impl QuantumLayoutCache {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn layout_of(&mut self, ty: &Ty) -> QuantumLayout {
-        if let Some(layout) = self.cache.get(ty) {
-            return layout.clone();
-        }
-        let layout = self.build(ty);
-        self.cache.insert(ty.clone(), layout.clone());
-        layout
-    }
-
-    fn build(&mut self, ty: &Ty) -> QuantumLayout {
-        match ty {
-            Ty::Primitive(p) => QuantumLayout::Primitive(primitive_qubits(p)),
-            Ty::Struct(s) => {
-                let mut fields = Vec::new();
-                let mut offset = 0;
-                for (name, member) in s.iter() {
-                    if !member.is_quantum() {
-                        continue;
-                    }
-                    let layout = self.layout_of(member);
-                    let qubits = layout.qubits();
-                    fields.push(QuantumField {
-                        name: name.clone(),
-                        offset,
-                        layout,
-                    });
-                    offset += qubits;
-                }
-                QuantumLayout::Struct(fields)
-            }
-            Ty::Enum(e) => {
-                assert_eq!(
-                    e.variants.len(),
-                    2,
-                    "quantum enums must have exactly 2 variants, got {}",
-                    e.variants.len()
-                );
-                QuantumLayout::Enum(e.iter().map(|v| v.name().clone()).collect())
-            }
-            Ty::Array(_) => todo!("quantum array layout"),
-        }
-    }
-}
-
-
-#[derive(Clone, Debug)]
-pub struct QuantumInstruction {
-    pub ancilla: u32,
-}
-
-impl QuantumInstruction {
-    pub fn new(ancilla: u32) -> Self {
-        Self { ancilla }
-    }
-}
-
-
-#[derive(Clone, Debug)]
-pub struct QuantumProgram {
-    pub var: SymbolId,
-    pub layout: QuantumLayout,
-    pub instructions: Vec<QuantumInstruction>,
-    pub cast_attrs: Vec<SymbolId>,
-}
-
-impl QuantumProgram {
-    pub fn from_cast(var: SymbolId, ty: &Ty, cache: &mut QuantumLayoutCache) -> Self {
-        Self {
-            var,
-            layout: cache.layout_of(ty),
-            instructions: Vec::new(),
-            cast_attrs: Vec::new(),
-        }
-    }
-
-    pub fn add_instruction(&mut self, instr: QuantumInstruction) {
-        self.instructions.push(instr);
-    }
-
-    pub fn cast_attribute(&mut self, attr: SymbolId) {
-        self.cast_attrs.push(attr);
-    }
-
-    pub fn data_qubits(&self) -> u32 {
-        self.layout.qubits()
-    }
-
-    pub fn ancilla_qubits(&self) -> u32 {
-        self.instructions.iter().map(|i| i.ancilla).sum()
-    }
-
-    pub fn total_qubits(&self) -> u32 {
-        self.data_qubits() + self.ancilla_qubits()
-    }
-
-    pub fn classical_size(&self) -> u32 {
-        self.cast_attrs.len() as u32
+        TyPrimitive::Bool
+        | TyPrimitive::U32
+        | TyPrimitive::U64
+        | TyPrimitive::I32
+        | TyPrimitive::I64
+        | TyPrimitive::F32
+        | TyPrimitive::F64
+        | TyPrimitive::C64
+        | TyPrimitive::C128
+        | TyPrimitive::String => 0,
     }
 }
 
@@ -163,32 +59,9 @@ impl QuantumProgram {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::frontend::types::{TyEnum, TyStruct};
-    use crate::layout::arch::Arch;
-    use crate::layout::base::LayoutCache;
 
     fn qsym(pos: u32) -> SymbolId {
         SymbolId(pos, true)
-    }
-
-    fn csym(pos: u32) -> SymbolId {
-        SymbolId(pos, false)
-    }
-
-    fn bell_t() -> Ty {
-        let mut s = TyStruct::new(&qsym(0));
-        s.add_member(&qsym(1), Ty::Primitive(TyPrimitive::QBool));
-        s.add_member(&qsym(2), Ty::Primitive(TyPrimitive::QBool));
-        s.done();
-        Ty::Struct(s)
-    }
-
-    fn polarization() -> Ty {
-        let mut e = TyEnum::new(&qsym(10));
-        e.add_variant(&qsym(11), None);
-        e.add_variant(&qsym(12), None);
-        e.done();
-        Ty::Enum(e)
     }
 
     #[test]
@@ -201,111 +74,27 @@ mod tests {
     }
 
     #[test]
-    fn struct_sums_members() {
-        let mut cache = QuantumLayoutCache::new();
-        let layout = cache.layout_of(&bell_t());
-        assert_eq!(layout.qubits(), 2);
+    fn qubits_and_field_for_each_kind() {
+        assert_eq!(QuantumLayout::Primitive(TyPrimitive::QU4).qubits(), 4);
+        assert_eq!(QuantumLayout::Enum(qsym(0), [qsym(1), qsym(2)]).qubits(), 1);
 
-        let QuantumLayout::Struct(fields) = &layout else {
-            panic!("expected struct");
-        };
-        assert_eq!(fields.len(), 2);
-        assert_eq!(fields[0].offset, 0);
-        assert_eq!(fields[1].offset, 1);
-        assert_eq!(layout.field(&qsym(2)).unwrap().offset, 1);
-    }
-
-    #[test]
-    fn enum_is_one_qubit() {
-        let mut cache = QuantumLayoutCache::new();
-        let layout = cache.layout_of(&polarization());
-        assert_eq!(layout.qubits(), 1);
-
-        let QuantumLayout::Enum(variants) = &layout else {
-            panic!("expected enum");
-        };
-        assert_eq!(variants, &vec![qsym(11), qsym(12)]);
-    }
-
-    #[test]
-    fn nested_struct_recurses() {
-        let mut nested = TyStruct::new(&qsym(20));
-        nested.add_member(&qsym(21), bell_t());
-        nested.add_member(&qsym(22), Ty::Primitive(TyPrimitive::QU4));
-        nested.add_member(&qsym(23), polarization());
-        nested.done();
-
-        let mut cache = QuantumLayoutCache::new();
-        let layout = cache.layout_of(&Ty::Struct(nested));
-        assert_eq!(layout.qubits(), 7);
-
-        let QuantumLayout::Struct(fields) = &layout else {
-            panic!("expected struct");
-        };
-        let offsets: Vec<u32> = fields.iter().map(|f| f.offset).collect();
-        assert_eq!(offsets, vec![0, 2, 6]);
-    }
-
-    #[test]
-    fn struct_ignores_classical_members() {
-        let mut mixed = TyStruct::new(&qsym(30));
-        mixed.add_member(&qsym(31), Ty::Primitive(TyPrimitive::QBool));
-        mixed.add_member(&csym(32), Ty::Primitive(TyPrimitive::Bool));
-        mixed.done();
-
-        let mut cache = QuantumLayoutCache::new();
-        let layout = cache.layout_of(&Ty::Struct(mixed));
-        assert_eq!(layout.qubits(), 1);
-
-        let QuantumLayout::Struct(fields) = &layout else {
-            panic!("expected struct");
-        };
-        assert_eq!(fields.len(), 1);
-    }
-
-    #[test]
-    #[should_panic]
-    fn enum_rejects_more_than_two_variants() {
-        let mut e = TyEnum::new(&qsym(40));
-        e.add_variant(&qsym(41), None);
-        e.add_variant(&qsym(42), None);
-        e.add_variant(&qsym(43), None);
-        e.done();
-        QuantumLayoutCache::new().layout_of(&Ty::Enum(e));
-    }
-
-    #[test]
-    fn classical_layout_is_blind_quantum_layout_is_not() {
-        let mut classical = LayoutCache::new(Arch::get_arch64());
-        classical.initialize(Some(Arch::get_arch64()));
-        classical.insert_layout(&bell_t(), &Some(Arch::get_arch64()));
-        assert_eq!(classical.layout_of(&bell_t()).size(), 0);
-
-        let mut quantum = QuantumLayoutCache::new();
-        assert_eq!(
-            quantum.layout_of(&Ty::Primitive(TyPrimitive::QU4)).qubits(),
-            4
+        let s = QuantumLayout::Struct(
+            qsym(0),
+            vec![
+                QuantumField {
+                    name: qsym(1),
+                    offset: 0,
+                    layout: QuantumLayout::Primitive(TyPrimitive::QBool),
+                },
+                QuantumField {
+                    name: qsym(2),
+                    offset: 1,
+                    layout: QuantumLayout::Primitive(TyPrimitive::QU4),
+                },
+            ],
         );
-        assert_eq!(quantum.layout_of(&bell_t()).qubits(), 2);
-    }
-
-    #[test]
-    fn quantum_program_totals() {
-        let mut cache = QuantumLayoutCache::new();
-
-        let prog =
-            QuantumProgram::from_cast(qsym(50), &Ty::Primitive(TyPrimitive::QU4), &mut cache);
-        assert_eq!(prog.total_qubits(), 4);
-        assert_eq!(prog.classical_size(), 0);
-
-        for ancilla in [0u32, 1, 2, 3] {
-            let mut prog = QuantumProgram::from_cast(qsym(50), &bell_t(), &mut cache);
-            prog.add_instruction(QuantumInstruction::new(ancilla));
-            prog.cast_attribute(qsym(2));
-            assert_eq!(prog.data_qubits(), 2);
-            assert_eq!(prog.ancilla_qubits(), ancilla);
-            assert_eq!(prog.total_qubits(), 2 + ancilla);
-            assert_eq!(prog.classical_size(), 1);
-        }
+        assert_eq!(s.qubits(), 5);
+        assert_eq!(s.field(&qsym(2)).unwrap().offset, 1);
+        assert!(s.field(&qsym(9)).is_none());
     }
 }

--- a/rust/hhat_lang/hhat_core/src/layout/quantum_cache.rs
+++ b/rust/hhat_lang/hhat_core/src/layout/quantum_cache.rs
@@ -1,0 +1,199 @@
+use std::collections::HashMap;
+
+use crate::frontend::types::Ty;
+use crate::layout::quantum::{QuantumField, QuantumLayout};
+
+
+#[derive(Default)]
+pub struct QuantumLayoutCache {
+    cache: HashMap<Ty, QuantumLayout>,
+}
+
+impl QuantumLayoutCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn layout_of(&mut self, ty: &Ty) -> QuantumLayout {
+        if let Some(layout) = self.cache.get(ty) {
+            return layout.clone();
+        }
+        let layout = self.build(ty);
+        self.cache.insert(ty.clone(), layout.clone());
+        layout
+    }
+
+    fn build(&mut self, ty: &Ty) -> QuantumLayout {
+        match ty {
+            Ty::Primitive(p) => QuantumLayout::Primitive(p.clone()),
+            Ty::Struct(s) => {
+                let mut fields = Vec::new();
+                let mut offset = 0;
+                for (name, member) in s.iter() {
+                    if !member.is_quantum() {
+                        continue;
+                    }
+                    let layout = self.layout_of(member);
+                    let qubits = layout.qubits();
+                    fields.push(QuantumField {
+                        name: name.clone(),
+                        offset,
+                        layout,
+                    });
+                    offset += qubits;
+                }
+                QuantumLayout::Struct(s.name.clone(), fields)
+            }
+            Ty::Enum(e) => {
+                assert_eq!(
+                    e.variants.len(),
+                    2,
+                    "quantum enums must have exactly 2 variants, got {}",
+                    e.variants.len()
+                );
+                QuantumLayout::Enum(
+                    e.name.clone(),
+                    [
+                        e.variants[0].name().clone(),
+                        e.variants[1].name().clone(),
+                    ],
+                )
+            }
+            Ty::Array(_) => todo!("quantum array layout"),
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frontend::types::{TyEnum, TyPrimitive, TyStruct};
+    use crate::layout::arch::Arch;
+    use crate::layout::base::LayoutCache;
+    use crate::SymbolId;
+
+    fn qsym(pos: u32) -> SymbolId {
+        SymbolId(pos, true)
+    }
+
+    fn csym(pos: u32) -> SymbolId {
+        SymbolId(pos, false)
+    }
+
+    fn bell_t() -> Ty {
+        let mut s = TyStruct::new(&qsym(0));
+        s.add_member(&qsym(1), Ty::Primitive(TyPrimitive::QBool));
+        s.add_member(&qsym(2), Ty::Primitive(TyPrimitive::QBool));
+        s.done();
+        Ty::Struct(s)
+    }
+
+    fn polarization() -> Ty {
+        let mut e = TyEnum::new(&qsym(10));
+        e.add_variant(&qsym(11), None);
+        e.add_variant(&qsym(12), None);
+        e.done();
+        Ty::Enum(e)
+    }
+
+    #[test]
+    fn primitive_layout_keeps_type() {
+        let mut cache = QuantumLayoutCache::new();
+        assert!(matches!(
+            cache.layout_of(&Ty::Primitive(TyPrimitive::QU4)),
+            QuantumLayout::Primitive(TyPrimitive::QU4)
+        ));
+    }
+
+    #[test]
+    fn struct_sums_members() {
+        let mut cache = QuantumLayoutCache::new();
+        let layout = cache.layout_of(&bell_t());
+        assert_eq!(layout.qubits(), 2);
+
+        let QuantumLayout::Struct(name, fields) = &layout else {
+            panic!("expected struct");
+        };
+        assert_eq!(*name, qsym(0));
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].offset, 0);
+        assert_eq!(fields[1].offset, 1);
+        assert_eq!(layout.field(&qsym(2)).unwrap().offset, 1);
+    }
+
+    #[test]
+    fn enum_is_one_qubit() {
+        let mut cache = QuantumLayoutCache::new();
+        let layout = cache.layout_of(&polarization());
+        assert_eq!(layout.qubits(), 1);
+
+        let QuantumLayout::Enum(name, variants) = &layout else {
+            panic!("expected enum");
+        };
+        assert_eq!(*name, qsym(10));
+        assert_eq!(variants, &[qsym(11), qsym(12)]);
+    }
+
+    #[test]
+    fn nested_struct_recurses() {
+        let mut nested = TyStruct::new(&qsym(20));
+        nested.add_member(&qsym(21), bell_t());
+        nested.add_member(&qsym(22), Ty::Primitive(TyPrimitive::QU4));
+        nested.add_member(&qsym(23), polarization());
+        nested.done();
+
+        let mut cache = QuantumLayoutCache::new();
+        let layout = cache.layout_of(&Ty::Struct(nested));
+        assert_eq!(layout.qubits(), 7);
+
+        let QuantumLayout::Struct(_, fields) = &layout else {
+            panic!("expected struct");
+        };
+        let offsets: Vec<u32> = fields.iter().map(|f| f.offset).collect();
+        assert_eq!(offsets, vec![0, 2, 6]);
+    }
+
+    #[test]
+    fn struct_ignores_classical_members() {
+        let mut mixed = TyStruct::new(&qsym(30));
+        mixed.add_member(&qsym(31), Ty::Primitive(TyPrimitive::QBool));
+        mixed.add_member(&csym(32), Ty::Primitive(TyPrimitive::Bool));
+        mixed.done();
+
+        let mut cache = QuantumLayoutCache::new();
+        let layout = cache.layout_of(&Ty::Struct(mixed));
+        assert_eq!(layout.qubits(), 1);
+
+        let QuantumLayout::Struct(_, fields) = &layout else {
+            panic!("expected struct");
+        };
+        assert_eq!(fields.len(), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn enum_rejects_more_than_two_variants() {
+        let mut e = TyEnum::new(&qsym(40));
+        e.add_variant(&qsym(41), None);
+        e.add_variant(&qsym(42), None);
+        e.add_variant(&qsym(43), None);
+        e.done();
+        QuantumLayoutCache::new().layout_of(&Ty::Enum(e));
+    }
+
+    #[test]
+    fn classical_layout_is_blind_quantum_layout_is_not() {
+        let mut classical = LayoutCache::new(Arch::get_arch64());
+        classical.initialize(Some(Arch::get_arch64()));
+        classical.insert_layout(&bell_t(), &Some(Arch::get_arch64()));
+        assert_eq!(classical.layout_of(&bell_t()).size(), 0);
+
+        let mut quantum = QuantumLayoutCache::new();
+        assert_eq!(
+            quantum.layout_of(&Ty::Primitive(TyPrimitive::QU4)).qubits(),
+            4
+        );
+        assert_eq!(quantum.layout_of(&bell_t()).qubits(), 2);
+    }
+}

--- a/rust/hhat_lang/hhat_core/src/lib.rs
+++ b/rust/hhat_lang/hhat_core/src/lib.rs
@@ -4,11 +4,14 @@ pub mod frontend;
 pub mod backend;
 mod core;
 pub mod layout;
+pub mod program;
 
 pub use frontend::base::IRInfra;
 pub use backend::base::BackendCompiler;
 pub use core::{CoreCompiler, Literal, SymbolId};
-pub use layout::quantum::{QuantumInstruction, QuantumLayout, QuantumLayoutCache, QuantumProgram};
+pub use layout::quantum::QuantumLayout;
+pub use layout::quantum_cache::QuantumLayoutCache;
+pub use program::{QuantumInstruction, QuantumProgram};
 
 
 #[cfg(test)]

--- a/rust/hhat_lang/hhat_core/src/lib.rs
+++ b/rust/hhat_lang/hhat_core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod layout;
 pub use frontend::base::IRInfra;
 pub use backend::base::BackendCompiler;
 pub use core::{CoreCompiler, Literal, SymbolId};
+pub use layout::quantum::{QuantumInstruction, QuantumLayout, QuantumLayoutCache, QuantumProgram};
 
 
 #[cfg(test)]

--- a/rust/hhat_lang/hhat_core/src/program.rs
+++ b/rust/hhat_lang/hhat_core/src/program.rs
@@ -1,0 +1,99 @@
+use crate::frontend::types::Ty;
+use crate::layout::quantum::QuantumLayout;
+use crate::layout::quantum_cache::QuantumLayoutCache;
+use crate::SymbolId;
+
+
+#[derive(Clone, Debug)]
+pub struct QuantumInstruction {
+    pub ancilla: u32,
+}
+
+impl QuantumInstruction {
+    pub fn new(ancilla: u32) -> Self {
+        Self { ancilla }
+    }
+}
+
+
+#[derive(Clone, Debug)]
+pub struct QuantumProgram {
+    pub var: SymbolId,
+    pub layout: QuantumLayout,
+    pub instructions: Vec<QuantumInstruction>,
+    pub cast_attrs: Vec<SymbolId>,
+}
+
+impl QuantumProgram {
+    pub fn from_cast(var: SymbolId, ty: &Ty, cache: &mut QuantumLayoutCache) -> Self {
+        Self {
+            var,
+            layout: cache.layout_of(ty),
+            instructions: Vec::new(),
+            cast_attrs: Vec::new(),
+        }
+    }
+
+    pub fn add_instruction(&mut self, instr: QuantumInstruction) {
+        self.instructions.push(instr);
+    }
+
+    pub fn cast_attribute(&mut self, attr: SymbolId) {
+        self.cast_attrs.push(attr);
+    }
+
+    pub fn data_qubits(&self) -> u32 {
+        self.layout.qubits()
+    }
+
+    pub fn ancilla_qubits(&self) -> u32 {
+        self.instructions.iter().map(|i| i.ancilla).sum()
+    }
+
+    pub fn total_qubits(&self) -> u32 {
+        self.data_qubits() + self.ancilla_qubits()
+    }
+
+    pub fn classical_size(&self) -> u32 {
+        self.cast_attrs.len() as u32
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frontend::types::{TyPrimitive, TyStruct};
+
+    fn qsym(pos: u32) -> SymbolId {
+        SymbolId(pos, true)
+    }
+
+    fn bell_t() -> Ty {
+        let mut s = TyStruct::new(&qsym(0));
+        s.add_member(&qsym(1), Ty::Primitive(TyPrimitive::QBool));
+        s.add_member(&qsym(2), Ty::Primitive(TyPrimitive::QBool));
+        s.done();
+        Ty::Struct(s)
+    }
+
+    #[test]
+    fn quantum_program_totals() {
+        let mut cache = QuantumLayoutCache::new();
+
+        let prog =
+            QuantumProgram::from_cast(qsym(50), &Ty::Primitive(TyPrimitive::QU4), &mut cache);
+        assert_eq!(prog.total_qubits(), 4);
+        assert_eq!(prog.classical_size(), 0);
+
+        for ancilla in [0u32, 1, 2, 3] {
+            let mut prog = QuantumProgram::from_cast(qsym(50), &bell_t(), &mut cache);
+            prog.add_instruction(QuantumInstruction::new(ancilla));
+            prog.cast_attribute(qsym(2));
+            assert_eq!(prog.data_qubits(), 2);
+            assert_eq!(prog.ancilla_qubits(), ancilla);
+            assert_eq!(prog.total_qubits(), 2 + ancilla);
+            assert_eq!(prog.classical_size(), 1);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #113.

Adds a quantum memory layout for quantum data in `hhat_core`, built when a quantum
variable is cast. It's the quantum sibling of the classical layout: where `LayoutCache`
turns a `Ty` into a `TypeLayout` (bytes + alignment), this turns a quantum `Ty` into a
`QuantumLayout` (qubits, no alignment).

Sizing:
- primitives: `@bool`=1, `@u2`=2, `@u3`=3, `@u4`=4, `@u8`=8
- struct = sum of its quantum members, packed with no padding; classical members carry
  no qubits and stay under `LayoutCache`
- enum: 2 variants only (enforced), 1 qubit, first/second → `|0>`/`|1>`
- `QuantumProgram.total_qubits` = data qubits + instruction ancillas; classical register
  size = number of cast attributes

The Bell example gives `@bell_t` → 2 data qubits, and casting only `@v.@t` → a classical
register of 1.

Note: layouts are built from the `Ty`, not the classical `TypeLayout`, because the
classical layout is quantum-blind here (quantum primitives are zero-sized and quantum
struct fields are dropped). `QuantumLayout` is one recursive enum and the cache is lazy
(no separate `initialize`/`insert_layout`) — happy to add those back for parity with
`LayoutCache` if you prefer.

Scope: new `layout/quantum.rs`, one line in `layout/mod.rs`, a re-export in `lib.rs`; no
changes to the classical layout files.

Testing: `cargo test -p hhat_core --lib` — 8 new tests pass (primitive counts, struct
sum/offsets, enum + basis, nested recursion, classical members ignored, >2-variant enum
rejected, classical-blind vs quantum, `QuantumProgram` totals with ancillas 0–3). Clippy
clean on the new file; `cargo audit` clean.

> `cargo fmt --check`, `clippy -D warnings`, and the full workspace `cargo test` are
> already red on this branch before this change; I left those alone to keep it scoped to #113.

Open questions: keep the lazy cache or mirror `LayoutCache` exactly? And where should the
`QuantumProgram` live — I assumed the compiler driver owns it and wiring into the pipeline
+ Q3L is a follow-up.

---

### Generative AI/LLM disclosure

Code and Logic Architecture/Design:

- [ ] The code and logic architecture/design contain no generative AI/LLM
- [x] The code and logic architecture/design are partially performed by generative AI/LLM
  - **80%** performed by the author(s)
- [ ] The code and logic architecture/design are fully performed by generative AI/LLM

Code content:

- [ ] The code contains no generative AI/LLM work
- [x] The code is partially written by generative AI/LLM
  - **60%** performed by the author(s)
- [ ] The code is fully written by generative AI/LLM

Code review:

- [ ] The code review contains no generative AI/LLM
- [x] The code review is partially done by generative AI/LLM
  - **70%** performed by the author(s)
- [ ] The code review is fully done by generative AI/LLM

Code tests:

- [ ] The code tests contain no generative AI/LLM
- [x] The code tests are partially written by generative AI/LLM
  - **90%** performed by the author(s)
- [ ] The code tests are fully written by generative AI/LLM
